### PR TITLE
Add _params & params as properties of SarracenDataFrame.py

### DIFF
--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -3,6 +3,8 @@ from pandas import DataFrame
 
 class SarracenDataFrame(DataFrame):
 
+    _metadata = ['_params', 'params']
+
     def __init__(self, data=None, *args, **kwargs):
 
         # call pandas DataFrame contructor

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -3,13 +3,12 @@ from pandas import DataFrame
 
 class SarracenDataFrame(DataFrame):
 
-    _metadata = ['_params', 'params']
+    _metadata = ['_params']
 
     def __init__(self, data=None, *args, **kwargs):
 
         # call pandas DataFrame contructor
         super().__init__(data, *args, **kwargs)
-        self.params = dict()
 
     @property
     def params(self):


### PR DESCRIPTION
Includes `_params` & `params` in the metadata of `SarracenDataFrame.py`, to avoid a `UserWarning` thrown by pandas.