### PR TITLE
Implement CubicSplineKernel with Unit Tests

### DIFF
--- a/sarracen/kernels.py
+++ b/sarracen/kernels.py
@@ -1,0 +1,41 @@
+from math import pi
+
+
+class Kernel:
+    """A generic kernel used for data interpolation."""
+    def __init__(self, radkernel, cnormk1D, cnormk2D, cnormk3D, wfunc):
+        self._radkernel = radkernel
+        self._cnormk1D = cnormk1D
+        self._cnormk2D = cnormk2D
+        self._cnormk3D = cnormk3D
+        self._wfunc = wfunc
+
+    def value(self, q, dimension):
+        """
+        The dimensionless part of this kernel at a specific value of q.
+        :param q: The value of q to evaluate this kernel at.
+        :param dimension: The number of dimensions (for normalization)
+        :return:
+        """
+        norm = self._cnormk1D if (dimension == 1) else \
+            self._cnormk2D if (dimension == 2) else \
+            self._cnormk3D
+
+        return norm * self._wfunc(q)
+
+
+class CubicSplineKernel(Kernel):
+    """
+    An implementation of the Cubic Spline kernel, in 1, 2, and 3 dimensions.
+    """
+    def __init__(self):
+        super().__init__(2.0, 2./3., 10./(7.*pi), 1./pi, self._weight)
+
+    @staticmethod
+    def _weight(q):
+        if q < 1:
+            return 1 - (3./2.) * q**2 + (3./4.) * q**3
+        elif q < 2:
+            return (1./4.) * (2 - q)**3
+        else:
+            return 0

--- a/sarracen/tests/test_kernels.py
+++ b/sarracen/tests/test_kernels.py
@@ -1,0 +1,22 @@
+from sarracen.kernels import CubicSplineKernel
+from math import pi
+
+
+class TestKernels:
+    def test_cubicspline(self):
+        kernel = CubicSplineKernel()
+
+        # testing kernel values at q = 0
+        # which should be equal to the normalization constants
+        assert kernel.value(0, 1) == 2/3
+        assert kernel.value(0, 2) == 10 / (7*pi)
+        assert kernel.value(0, 3) == 1 / pi
+
+        # testing kernel values at q = 1
+        assert kernel.value(1, 1) == 1/6
+        assert kernel.value(1, 2) == 5 / (14 * pi)
+        assert kernel.value(1, 3) == 1 / (4 * pi)
+
+        # testing kernel values at q = 2
+        assert kernel.value(2, 2) == 0
+        assert kernel.value(10, 3) == 0


### PR DESCRIPTION
Implements the cubic spline kernel, normalized in one, two, and three dimensions. `test_cubicspline` has been created to test this implementation.

The cubic spline kernel is a subclass of the generic `Kernel` class, which can be used to easily implement different types of kernels.