### PR TITLE
Implementation of 2D Interpolation

### DIFF
--- a/sarracen/interpolate.py
+++ b/sarracen/interpolate.py
@@ -19,7 +19,7 @@ def interpolate2D(data, x, y, target, kernel, xmin, ymin, pixwidthx, pixwidthy, 
     :param pixwidthy: The height that each pixel represents in particle data space
     :return: The output image, in a 2-dimensional numpy array.
     """
-    image = np.zeros((pixcountx, pixcounty))
+    image = np.zeros((pixcounty, pixcountx))
 
     # iterate through all pixels
     for i, particle in data.iterrows():
@@ -27,14 +27,12 @@ def interpolate2D(data, x, y, target, kernel, xmin, ymin, pixwidthx, pixwidthy, 
         # w_i = m_i / (rho_i * (h_i) ** 2)
         weight = particle['m'] / (particle['rho'] * particle['h'] ** 2)
 
-        # normalize the weight using the kernel normalization constant
-        termnorm = kernel.cnormk2D * weight
         # skip particles with 0 weight
-        if termnorm <= 0: continue
+        if weight <= 0: continue
 
         # kernel radius scaled by the particle's 'h' value
         radkern = kernel.radkernel * particle['h']
-        term = termnorm * particle[target]
+        term = weight * particle[target]
         hi1 = 1 / particle['h']
         hi21 = hi1 ** 2
 
@@ -42,10 +40,10 @@ def interpolate2D(data, x, y, target, kernel, xmin, ymin, pixwidthx, pixwidthy, 
         part_y = particle[y]
 
         # determine the min/max x&y coordinates affected by this particle
-        ipixmin = int((part_x - radkern - xmin)/np.abs(pixwidthx))
-        jpixmin = int((part_y - radkern - ymin)/np.abs(pixwidthy))
-        ipixmax = int((part_x + radkern - xmin)/np.abs(pixwidthx))
-        jpixmax = int((part_y + radkern - ymin)/np.abs(pixwidthy))
+        ipixmin = int(np.rint((part_x - radkern - xmin)/np.abs(pixwidthx)))
+        jpixmin = int(np.rint((part_y - radkern - ymin)/np.abs(pixwidthy)))
+        ipixmax = int(np.rint((part_x + radkern - xmin)/np.abs(pixwidthx)))
+        jpixmax = int(np.rint((part_y + radkern - ymin)/np.abs(pixwidthy)))
 
         # ensure that the min/max x&y coordinates remain within the bounds of the image
         if ipixmin < 0: ipixmin = 0
@@ -56,21 +54,21 @@ def interpolate2D(data, x, y, target, kernel, xmin, ymin, pixwidthx, pixwidthy, 
         # precalculate derivatives in the x-direction (optimization)
         dx2i = np.zeros(pixcountx)
         for ipix in range(ipixmin, ipixmax):
-            dx2i[ipix] = ((xmin + (ipix - 0.5) * pixwidthx - part_x) ** 2) * hi21
+            dx2i[ipix] = ((xmin + (ipix + 0.5) * pixwidthx - part_x) ** 2) * hi21
 
         # traverse horizontally through affected pixels
         for jpix in range(jpixmin, jpixmax):
             # determine derivatives in the y-direction
-            ypix = ymin + (jpix - 0.5) * pixwidthy
+            ypix = ymin + (jpix + 0.5) * pixwidthy
             dy = ypix - part_y
             dy2 = dy * dy * hi21
 
             for ipix in range(ipixmin, ipixmax):
                 # calculate contribution at i, j due to particle at x, y
                 q2 = dx2i[ipix] + dy2
-                wab = kernel.w(q2, 2)
+                wab = kernel.w(np.sqrt(q2), 2)
 
                 # add contribution to image
-                image[ipix][jpix] += term * wab
+                image[jpix][ipix] += term * wab
 
     return image

--- a/sarracen/interpolate.py
+++ b/sarracen/interpolate.py
@@ -1,0 +1,76 @@
+import numpy as np
+
+
+def interpolate2D(data, x, y, target, kernel, xmin, ymin, pixwidthx, pixwidthy, pixcountx, pixcounty):
+    """
+    Interpolates particle data in a SarracenDataFrame across two directional axes to a 2D
+    grid of pixels.
+
+    :param data: The particle data, in a SarracenDataFrame.
+    :param x: The column label of the x-directional axis.
+    :param y: The column label of the y-directional axis.
+    :param target: The column label of the target smoothing data.
+    :param kernel: The kernel to use for smoothing the target data.
+    :param xmin: The starting x-coordinate (in particle data space)
+    :param ymin: The starting y-coordinate (in particle data space)
+    :param pixcountx: The number of pixels in the output image in the x-direction
+    :param pixcounty: The number of pixels in the output image in the y-direction
+    :param pixwidthx: The width that each pixel represents in particle data space.
+    :param pixwidthy: The height that each pixel represents in particle data space
+    :return: The output image, in a 2-dimensional numpy array.
+    """
+    image = np.zeros((pixcountx, pixcounty))
+
+    # iterate through all pixels
+    for i, particle in data.iterrows():
+        # dimensionless weight
+        # w_i = m_i / (rho_i * (h_i) ** 2)
+        weight = particle['m'] / (particle['rho'] * particle['h'] ** 2)
+
+        # normalize the weight using the kernel normalization constant
+        termnorm = kernel.cnormk2D * weight
+        # skip particles with 0 weight
+        if termnorm <= 0: continue
+
+        # kernel radius scaled by the particle's 'h' value
+        radkern = kernel.radkernel * particle['h']
+        term = termnorm * particle[target]
+        hi1 = 1 / particle['h']
+        hi21 = hi1 ** 2
+
+        part_x = particle[x]
+        part_y = particle[y]
+
+        # determine the min/max x&y coordinates affected by this particle
+        ipixmin = int((part_x - radkern - xmin)/np.abs(pixwidthx))
+        jpixmin = int((part_y - radkern - ymin)/np.abs(pixwidthy))
+        ipixmax = int((part_x + radkern - xmin)/np.abs(pixwidthx))
+        jpixmax = int((part_y + radkern - ymin)/np.abs(pixwidthy))
+
+        # ensure that the min/max x&y coordinates remain within the bounds of the image
+        if ipixmin < 0: ipixmin = 0
+        if ipixmax > pixcountx: ipixmax = pixcountx
+        if jpixmin < 0: jpixmin = 0
+        if jpixmax > pixcounty: jpixmax = pixcounty
+
+        # precalculate derivatives in the x-direction (optimization)
+        dx2i = np.zeros(pixcountx)
+        for ipix in range(ipixmin, ipixmax):
+            dx2i[ipix] = ((xmin + (ipix - 0.5) * pixwidthx - part_x) ** 2) * hi21
+
+        # traverse horizontally through affected pixels
+        for jpix in range(jpixmin, jpixmax):
+            # determine derivatives in the y-direction
+            ypix = ymin + (jpix - 0.5) * pixwidthy
+            dy = ypix - part_y
+            dy2 = dy * dy * hi21
+
+            for ipix in range(ipixmin, ipixmax):
+                # calculate contribution at i, j due to particle at x, y
+                q2 = dx2i[ipix] + dy2
+                wab = kernel.w(q2, 2)
+
+                # add contribution to image
+                image[ipix][jpix] += term * wab
+
+    return image

--- a/sarracen/interpolate.py
+++ b/sarracen/interpolate.py
@@ -1,7 +1,20 @@
 import numpy as np
 
+from sarracen import SarracenDataFrame
+from sarracen.kernels import Kernel
 
-def interpolate2D(data, x, y, target, kernel, xmin, ymin, pixwidthx, pixwidthy, pixcountx, pixcounty):
+
+def interpolate2D(data: SarracenDataFrame,
+                  x: str,
+                  y: str,
+                  target: str,
+                  kernel: Kernel,
+                  pixwidthx: float,
+                  pixwidthy: float,
+                  xmin: float = 0,
+                  ymin: float = 0,
+                  pixcountx: int = 480,
+                  pixcounty: int = 480):
     """
     Interpolates particle data in a SarracenDataFrame across two directional axes to a 2D
     grid of pixels.
@@ -11,14 +24,23 @@ def interpolate2D(data, x, y, target, kernel, xmin, ymin, pixwidthx, pixwidthy, 
     :param y: The column label of the y-directional axis.
     :param target: The column label of the target smoothing data.
     :param kernel: The kernel to use for smoothing the target data.
+    :param pixwidthx: The width that each pixel represents in particle data space.
+    :param pixwidthy: The height that each pixel represents in particle data space.
     :param xmin: The starting x-coordinate (in particle data space).
     :param ymin: The starting y-coordinate (in particle data space).
-    :param pixwidthx: The width that each pixel represents in particle data space.
-    :param pixwidthy: The height that each pixel represents in particle data space
     :param pixcountx: The number of pixels in the output image in the x-direction.
     :param pixcounty: The number of pixels in the output image in the y-direction.
     :return: The output image, in a 2-dimensional numpy array.
     """
+    if pixwidthx <= 0:
+        raise ValueError("pixwidthx must be greater than zero!")
+    if pixwidthy <= 0:
+        raise ValueError("pixwidthy must be greater than zero!")
+    if pixcountx <= 0:
+        raise ValueError(f"pixcountx must be greater than zero!")
+    if pixcounty <= 0:
+        raise ValueError(f"pixcounty must be greater than zero!")
+
     image = np.zeros((pixcounty, pixcountx))
 
     # iterate through all pixels
@@ -28,7 +50,8 @@ def interpolate2D(data, x, y, target, kernel, xmin, ymin, pixwidthx, pixwidthy, 
         weight = particle['m'] / (particle['rho'] * particle['h'] ** 2)
 
         # skip particles with 0 weight
-        if weight <= 0: continue
+        if weight <= 0:
+            continue
 
         # kernel radius scaled by the particle's 'h' value
         radkern = kernel.radkernel * particle['h']
@@ -40,25 +63,29 @@ def interpolate2D(data, x, y, target, kernel, xmin, ymin, pixwidthx, pixwidthy, 
         part_y = particle[y]
 
         # determine the min/max x&y coordinates affected by this particle
-        ipixmin = int(np.rint((part_x - radkern - xmin)/np.abs(pixwidthx)))
-        jpixmin = int(np.rint((part_y - radkern - ymin)/np.abs(pixwidthy)))
-        ipixmax = int(np.rint((part_x + radkern - xmin)/np.abs(pixwidthx)))
-        jpixmax = int(np.rint((part_y + radkern - ymin)/np.abs(pixwidthy)))
+        ipixmin = int(np.rint((part_x - radkern - xmin) / pixwidthx))
+        jpixmin = int(np.rint((part_y - radkern - ymin) / pixwidthy))
+        ipixmax = int(np.rint((part_x + radkern - xmin) / pixwidthx))
+        jpixmax = int(np.rint((part_y + radkern - ymin) / pixwidthy))
 
         # ensure that the min/max x&y coordinates remain within the bounds of the image
-        if ipixmin < 0: ipixmin = 0
-        if ipixmax > pixcountx: ipixmax = pixcountx
-        if jpixmin < 0: jpixmin = 0
-        if jpixmax > pixcounty: jpixmax = pixcounty
+        if ipixmin < 0:
+            ipixmin = 0
+        if ipixmax > pixcountx:
+            ipixmax = pixcountx
+        if jpixmin < 0:
+            jpixmin = 0
+        if jpixmax > pixcounty:
+            jpixmax = pixcounty
 
-        # precalculate derivatives in the x-direction (optimization)
+        # precalculate differences in the x-direction (optimization)
         dx2i = np.zeros(pixcountx)
         for ipix in range(ipixmin, ipixmax):
             dx2i[ipix] = ((xmin + (ipix + 0.5) * pixwidthx - part_x) ** 2) * hi21
 
         # traverse horizontally through affected pixels
         for jpix in range(jpixmin, jpixmax):
-            # determine derivatives in the y-direction
+            # determine differences in the y-direction
             ypix = ymin + (jpix + 0.5) * pixwidthy
             dy = ypix - part_y
             dy2 = dy * dy * hi21

--- a/sarracen/interpolate.py
+++ b/sarracen/interpolate.py
@@ -11,12 +11,12 @@ def interpolate2D(data, x, y, target, kernel, xmin, ymin, pixwidthx, pixwidthy, 
     :param y: The column label of the y-directional axis.
     :param target: The column label of the target smoothing data.
     :param kernel: The kernel to use for smoothing the target data.
-    :param xmin: The starting x-coordinate (in particle data space)
-    :param ymin: The starting y-coordinate (in particle data space)
-    :param pixcountx: The number of pixels in the output image in the x-direction
-    :param pixcounty: The number of pixels in the output image in the y-direction
+    :param xmin: The starting x-coordinate (in particle data space).
+    :param ymin: The starting y-coordinate (in particle data space).
     :param pixwidthx: The width that each pixel represents in particle data space.
     :param pixwidthy: The height that each pixel represents in particle data space
+    :param pixcountx: The number of pixels in the output image in the x-direction.
+    :param pixcounty: The number of pixels in the output image in the y-direction.
     :return: The output image, in a 2-dimensional numpy array.
     """
     image = np.zeros((pixcounty, pixcountx))

--- a/sarracen/kernels.py
+++ b/sarracen/kernels.py
@@ -23,6 +23,22 @@ class Kernel:
 
         return norm * self._wfunc(q)
 
+    @property
+    def radkernel(self):
+        return self._radkernel
+
+    @radkernel.getter
+    def radkernel(self):
+        return self._radkernel
+
+    @property
+    def cnormk2D(self):
+        return self._cnormk2D
+
+    @cnormk2D.getter
+    def cnormk2D(self):
+        return self._cnormk2D
+
 
 class CubicSplineKernel(Kernel):
     """

--- a/sarracen/tests/test_interpolate.py
+++ b/sarracen/tests/test_interpolate.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 from pytest import approx
 
 from sarracen import SarracenDataFrame
@@ -15,10 +16,9 @@ def test_interpolate2d():
                        'm': [1]})
     sdf = SarracenDataFrame(df, params=dict())
 
-    image = interpolate2D(sdf, 'x', 'y', 'P', CubicSplineKernel(), -2, -2, 0.1, 0.1, 40, 40)
+    image = interpolate2D(sdf, 'x', 'y', 'P', CubicSplineKernel(), 0.1, 0.1, -2, -2, 40, 40)
 
     assert image[0][0] == 0
-    # sqrt((-1.95)^2+(0.05)^2)
-    assert image[20][0] == approx(CubicSplineKernel().w(1.95064, 2), rel=1e-4)
-    # sqrt((0.05)^2+(0.05)^2)
-    assert image[20][20] == approx(CubicSplineKernel().w(0.070711, 2), rel=1e-4)
+    assert image[20][0] == approx(CubicSplineKernel().w(np.sqrt((-1.95) ** 2 + 0.05 ** 2), 2), rel=1e-8)
+    assert image[20][20] == approx(CubicSplineKernel().w(np.sqrt(0.05 ** 2 + 0.05 ** 2), 2), rel=1e-8)
+    assert image[12][17] == approx(CubicSplineKernel().w(np.sqrt(0.75 ** 2 + 0.25 ** 2), 2), rel=1e-8)

--- a/sarracen/tests/test_interpolate.py
+++ b/sarracen/tests/test_interpolate.py
@@ -1,0 +1,24 @@
+import pandas as pd
+from pytest import approx
+
+from sarracen import SarracenDataFrame
+from sarracen.kernels import CubicSplineKernel
+from sarracen.interpolate import interpolate2D
+
+
+def test_interpolate2d():
+    df = pd.DataFrame({'x': [0],
+                       'y': [0],
+                       'P': [1],
+                       'h': [1],
+                       'rho': [1],
+                       'm': [1]})
+    sdf = SarracenDataFrame(df, params=dict())
+
+    image = interpolate2D(sdf, 'x', 'y', 'P', CubicSplineKernel(), -2, -2, 0.1, 0.1, 40, 40)
+
+    assert image[0][0] == 0
+    # sqrt((-1.95)^2+(0.05)^2)
+    assert image[20][0] == approx(CubicSplineKernel().w(1.95064, 2), rel=1e-4)
+    # sqrt((0.05)^2+(0.05)^2)
+    assert image[20][20] == approx(CubicSplineKernel().w(0.070711, 2), rel=1e-4)


### PR DESCRIPTION
Introduces the `interpolate2D` function, which maps particle data to a 2D grid of pixels. The data from a `SarracenDataFrame` along two axes is plotted with a user-defined smoothing kernel.

Example of a plot created using the `interpolate2D` function:
![image](https://user-images.githubusercontent.com/71343838/166728612-d90f6271-81bc-4df3-bbda-15b0827b8330.png)

```
image = interpolate2D(df, 'rx', 'ry', 'P', CubicSplineKernel(), 0, 0, 0.015624, 0.015624, 64, 128)

fig, ax = plt.subplots(figsize=(3, 4))
img = ax.imshow(image, cmap='RdBu', origin='lower', vmin=0.985, vmax=1.015, extent=[0, 1, 0, 2])
ax.set_xlabel('rx')
ax.set_ylabel('ry')
fig.colorbar(img, ax=ax, label='P')
plt.show()
```
