### PR TITLE
2D Interpolation plotting

### DIFF
--- a/sarracen/interpolate.py
+++ b/sarracen/interpolate.py
@@ -1,10 +1,9 @@
 import numpy as np
 
-from sarracen import SarracenDataFrame
 from sarracen.kernels import BaseKernel
 
 
-def interpolate2D(data: SarracenDataFrame,
+def interpolate2D(data: 'SarracenDataFrame',
                   x: str,
                   y: str,
                   target: str,

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -1,0 +1,30 @@
+from matplotlib import pyplot as plt
+
+from sarracen.interpolate import interpolate2D
+from sarracen.kernels import BaseKernel
+
+
+def render(data: 'SarracenDataFrame',
+           x: str,
+           y: str,
+           target: str,
+           kernel: 'BaseKernel',
+           xmin: float = 0,
+           ymin: float = 0,
+           xmax: float = 1,
+           ymax: float = 1,
+           pixcountx: int = 480,
+           pixcounty: int = 480):
+    pixwidthx = (xmax - xmin) / pixcountx
+    pixwidthy = (ymax - ymin) / pixcounty
+    image = interpolate2D(data, x, y, target, kernel, pixwidthx, pixwidthy, xmin, ymin, pixcountx, pixcounty)
+
+    # this figsize approximation seems to work well enough in most cases
+    fig, ax = plt.subplots(figsize=(4, 3*((ymax - ymin) / (xmax - xmin))))
+    img = ax.imshow(image, cmap='RdBu', origin='lower', extent=[xmin, xmax, ymin, ymax])
+    ax.set_xlabel(x)
+    ax.set_ylabel(y)
+    cbar = fig.colorbar(img, ax=ax)
+    cbar.ax.set_ylabel(target)
+
+    return fig, ax

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -26,7 +26,7 @@ def render(data: 'SarracenDataFrame',
            ymin: float = None,
            xmax: float = None,
            ymax: float = None,
-           pixcountx: int = 128,
+           pixcountx: int = 256,
            pixcounty: int = None) -> ('Figure', 'Axes'):
     """
     Render the data within a SarracenDataFrame to a 2D matplotlib object, using 2D SPH Interpolation

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -1,26 +1,74 @@
+import numpy as np
 from matplotlib import pyplot as plt
 
 from sarracen.interpolate import interpolate2D
-from sarracen.kernels import BaseKernel
+from sarracen.kernels import BaseKernel, CubicSplineKernel
+
+
+def snap(value: float):
+    """
+    Return a number snapped to the nearest integer, with 1e-4 tolerance.
+    :param value: The number to snap.
+    :return: An integer if a close integer is detected, otherwise return 'value'.
+    """
+    if np.isclose(value, np.rint(value), atol=1e-4):
+        return np.rint(value)
+    else:
+        return value
 
 
 def render(data: 'SarracenDataFrame',
-           x: str,
-           y: str,
            target: str,
-           kernel: 'BaseKernel',
-           xmin: float = 0,
-           ymin: float = 0,
-           xmax: float = 1,
-           ymax: float = 1,
-           pixcountx: int = 480,
-           pixcounty: int = 480):
+           x: str = None,
+           y: str = None,
+           kernel: BaseKernel = CubicSplineKernel(2),
+           xmin: float = None,
+           ymin: float = None,
+           xmax: float = None,
+           ymax: float = None,
+           pixcountx: int = 128,
+           pixcounty: int = None) -> ('Figure', 'Axes'):
+    """
+    Render the data within a SarracenDataFrame to a 2D matplotlib object, using 2D SPH Interpolation
+    of the target variable.
+    :param data: The SarracenDataFrame to render. [Required]
+    :param target: The variable to interpolate over. [Required]
+    :param x: The positional x variable.
+    :param y: The positional y variable.
+    :param kernel: The smoothing kernel to use for interpolation.
+    :param xmin: The minimum bound in the x-direction.
+    :param ymin: The minimum bound in the y-direction.
+    :param xmax: The maximum bound in the x-direction.
+    :param ymax: The maximum bound in the y-direction.
+    :param pixcountx: The number of pixels in the x-direction.
+    :param pixcounty: The number of pixels in the y-direction.
+    :return: The completed plot.
+    """
+    # x & y columns default to the variables determined by the SarracenDataFrame.
+    if x is None:
+        x = data.xcol
+    if y is None:
+        y = data.ycol
+
+    # snap the bounds of the plot to the nearest integer.
+    if xmin is None:
+        xmin = snap(data.loc[:, x].min())
+    if ymin is None:
+        ymin = snap(data.loc[:, y].min())
+    if xmax is None:
+        xmax = snap(data.loc[:, x].max())
+    if ymax is None:
+        ymax = snap(data.loc[:, y].max())
+    # set pixcounty to maintain an aspect ratio that is the same as the underlying bounds of the data.
+    if pixcounty is None:
+        pixcounty = int(np.rint(pixcountx * ((ymax - ymin) / (xmax - xmin))))
+
     pixwidthx = (xmax - xmin) / pixcountx
     pixwidthy = (ymax - ymin) / pixcounty
     image = interpolate2D(data, x, y, target, kernel, pixwidthx, pixwidthy, xmin, ymin, pixcountx, pixcounty)
 
     # this figsize approximation seems to work well enough in most cases
-    fig, ax = plt.subplots(figsize=(4, 3*((ymax - ymin) / (xmax - xmin))))
+    fig, ax = plt.subplots(figsize=(4, 3 * ((ymax - ymin) / (xmax - xmin))))
     img = ax.imshow(image, cmap='RdBu', origin='lower', extent=[xmin, xmax, ymin, ymax])
     ax.set_xlabel(x)
     ax.set_ylabel(y)

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -1,6 +1,9 @@
 from pandas import DataFrame, Series
 import numpy as np
 
+from sarracen.render import render
+from sarracen.kernels import CubicSplineKernel, BaseKernel
+
 
 class SarracenDataFrame(DataFrame):
 
@@ -17,6 +20,18 @@ class SarracenDataFrame(DataFrame):
         self._units = None
         self.units = Series([np.nan for i in range(len(self.columns))])
 
+    def render(self,
+               target: str,
+               x: str = 'x',
+               y: str = 'y',
+               kernel: BaseKernel = CubicSplineKernel(2),
+               xmin: float = 0,
+               ymin: float = 0,
+               xmax: float = 1,
+               ymax: float = 1,
+               pixcountx: int = 480,
+               pixcounty: int = 480):
+        render(self, x, y, target, kernel, xmin, ymin, xmax, ymax, pixcountx, pixcounty)
 
     @property
     def params(self):

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -4,10 +4,8 @@ import numpy as np
 from sarracen.render import render
 from sarracen.kernels import CubicSplineKernel, BaseKernel
 
-
 class SarracenDataFrame(DataFrame):
-
-    _metadata = ['_params', '_units']
+    _metadata = ['_params', '_units', '_xcol', '_ycol']
 
     def __init__(self, data=None, params=None, *args, **kwargs):
 
@@ -20,18 +18,50 @@ class SarracenDataFrame(DataFrame):
         self._units = None
         self.units = Series([np.nan for i in range(len(self.columns))])
 
+        # First look for 'x', then 'rx', and then fallback to the first column.
+        if 'x' in data.columns:
+            self._xcol = 'x'
+        elif 'rx' in data.columns:
+            self._xcol = 'rx'
+        else:
+            self._xcol = data.columns[0]
+
+        # First look for 'y', then 'ry', and then fallback to the second column.
+        if 'y' in data.columns:
+            self._ycol = 'y'
+        elif 'ry' in data.columns:
+            self._ycol = 'ry'
+        else:
+            self._ycol = data.columns[1]
+
     def render(self,
                target: str,
-               x: str = 'x',
-               y: str = 'y',
+               x: str = None,
+               y: str = None,
                kernel: BaseKernel = CubicSplineKernel(2),
-               xmin: float = 0,
-               ymin: float = 0,
-               xmax: float = 1,
-               ymax: float = 1,
-               pixcountx: int = 480,
-               pixcounty: int = 480):
-        render(self, x, y, target, kernel, xmin, ymin, xmax, ymax, pixcountx, pixcounty)
+               xmin: float = None,
+               ymin: float = None,
+               xmax: float = None,
+               ymax: float = None,
+               pixcountx: int = 128,
+               pixcounty: int = None) -> ('Figure', 'Axes'):
+        """
+        Render the data within this dataframe to a 2D matplotlib object, using 2D SPH Interpolation of the target
+        variable.
+        :param target: The variable to interpolate over. [Required]
+        :param x: The positional x variable.
+        :param y: The positional y variable.
+        :param kernel: The smoothing kernel to use for interpolation.
+        :param xmin: The minimum bound in the x-direction.
+        :param ymin: The minimum bound in the y-direction.
+        :param xmax: The maximum bound in the x-direction.
+        :param ymax: The maximum bound in the y-direction.
+        :param pixcountx: The number of pixels in the x-direction.
+        :param pixcounty: The number of pixels in the y-direction.
+        :return: The completed plot.
+        """
+
+        return render(self, target, x, y, kernel, xmin, ymin, xmax, ymax, pixcountx, pixcounty)
 
     @property
     def params(self):
@@ -61,3 +91,19 @@ class SarracenDataFrame(DataFrame):
     @units.getter
     def units(self):
         return self._units
+
+    @property
+    def xcol(self):
+        return self._xcol
+
+    @xcol.getter
+    def xcol(self):
+        return self._xcol
+
+    @property
+    def ycol(self):
+        return self._ycol
+
+    @ycol.getter
+    def ycol(self):
+        return self._ycol

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -43,7 +43,7 @@ class SarracenDataFrame(DataFrame):
                ymin: float = None,
                xmax: float = None,
                ymax: float = None,
-               pixcountx: int = 128,
+               pixcountx: int = 256,
                pixcounty: int = None) -> ('Figure', 'Axes'):
         """
         Render the data within this dataframe to a 2D matplotlib object, using 2D SPH Interpolation of the target

--- a/sarracen/tests/test_render.py
+++ b/sarracen/tests/test_render.py
@@ -1,10 +1,16 @@
 import pandas as pd
+import numpy as np
+from matplotlib import pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 
 from sarracen import SarracenDataFrame
+from sarracen.kernels import CubicSplineKernel
 
-def test_snapping():
-    df = pd.DataFrame({'x': [0.0001, 5.2],
-                       'y': [3.00004, 0.1],
+
+def test_plot_properties():
+    df = pd.DataFrame({'x': [3, 6],
+                       'y': [5, 1],
                        'P': [1, 1],
                        'h': [1, 1],
                        'rho': [1, 1],
@@ -13,7 +19,21 @@ def test_snapping():
 
     fig, ax = sdf.render('P')
 
-    # [0.0001, 5.2] -> (0.0, 5.2)
-    assert ax.get_xlim() == (0.0, 5.2)
-    # [3.00004, 0.1] -> (0.1, 3.0)
-    assert ax.get_ylim() == (0.1, 3.0)
+    assert isinstance(fig, Figure)
+    assert isinstance(ax, Axes)
+
+    assert ax.get_xlabel() == 'x'
+    assert ax.get_ylabel() == 'y'
+    # the colorbar is contained in a second axes object inside the figure
+    assert fig.axes[1].get_ylabel() == 'P'
+
+    assert ax.get_xlim() == (3, 6)
+    assert ax.get_ylim() == (1, 5)
+
+    # aspect ratio of data max & min is 4/3,
+    # pixel count => (256, 341)
+    # pixel width => (3/256, 4/341)
+    # both particles are in corners
+    # therefore closest pixel is => sqrt((3/512)**2, (2/341)**2)
+    # use default kernel to determine the max pressure value
+    assert fig.axes[1].get_ylim() == (0, CubicSplineKernel(2).w(np.sqrt((3/512)**2 + (2/341)**2)))

--- a/sarracen/tests/test_render.py
+++ b/sarracen/tests/test_render.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+from sarracen import SarracenDataFrame
+
+def test_snapping():
+    df = pd.DataFrame({'x': [0.0001, 5.2],
+                       'y': [3.00004, 0.1],
+                       'P': [1, 1],
+                       'h': [1, 1],
+                       'rho': [1, 1],
+                       'm': [1, 1]})
+    sdf = SarracenDataFrame(df)
+
+    fig, ax = sdf.render('P')
+
+    # [0.0001, 5.2] -> (0.0, 5.2)
+    assert ax.get_xlim() == (0.0, 5.2)
+    # [3.00004, 0.1] -> (0.1, 3.0)
+    assert ax.get_ylim() == (0.1, 3.0)

--- a/sarracen/tests/test_sarracen_dataframe.py
+++ b/sarracen/tests/test_sarracen_dataframe.py
@@ -1,0 +1,41 @@
+import pandas as pd
+
+from sarracen import SarracenDataFrame
+
+
+def test_position():
+    # The 'x' and 'y' keywords should be detected.
+    df = pd.DataFrame({'P': [1, 1],
+                       'h': [1, 1],
+                       'rho': [1, 1],
+                       'x': [5, 6],
+                       'y': [5, 4],
+                       'm': [1, 1]})
+    sdf = SarracenDataFrame(df)
+
+    assert sdf.xcol == 'x'
+    assert sdf.ycol == 'y'
+
+    # The 'rx' and 'ry' keywords should be detected.
+    df = pd.DataFrame({'ry': [-1, 1],
+                       'h': [1, 1],
+                       'rho': [1, 1],
+                       'rx': [3, 4],
+                       'P': [1, 1],
+                       'm': [1, 1]})
+    sdf = SarracenDataFrame(df)
+
+    assert sdf.xcol == 'rx'
+    assert sdf.ycol == 'ry'
+
+    # No keywords, so fall back to the first two columns.
+    df = pd.DataFrame({'i': [3.4, 2.1],
+                       'j': [4.9, 1.6],
+                       'h': [1, 1],
+                       'rho': [1, 1],
+                       'P': [1, 1],
+                       'm': [1, 1]})
+    sdf = SarracenDataFrame(df)
+
+    assert sdf.xcol == 'i'
+    assert sdf.ycol == 'j'

--- a/sarracen/tests/test_sarracen_dataframe.py
+++ b/sarracen/tests/test_sarracen_dataframe.py
@@ -39,3 +39,22 @@ def test_position():
 
     assert sdf.xcol == 'i'
     assert sdf.ycol == 'j'
+
+
+def test_snap():
+    df = pd.DataFrame({'x': [0.0001, 5.2],
+                       'y': [3.00004, 0.1],
+                       'P': [1, 1],
+                       'h': [1, 1],
+                       'rho': [1, 1],
+                       'm': [1, 1]})
+    sdf = SarracenDataFrame(df)
+
+    # 0.0001 -> 0.0
+    assert sdf.xmin == 0.0
+    # 5.2 -> 5.2
+    assert sdf.xmax == 5.2
+    # 0.1 -> 0.1
+    assert sdf.ymin == 0.1
+    # 3.00004 -> 3.0
+    assert sdf.ymax == 3.0


### PR DESCRIPTION
Creates a function in `SarracenDataFrame` `render(target)`, which produces and returns a matplotlib figure & axes containing a 2D interpolated plot of the provided variable. The directional axes, bounds of the plot, kernel, and resolution are determined automatically, or can be manually tuned by the user.

By default, arguments are selected by the following rules:

- x & y: First look for the keywords 'x' and 'y' or 'rx' and 'ry' in the columns. If these are not found, fallback to the first two columns.
- kernel: A CubicSplineKernel is chosen by default.
- xmin, ymin, xmax, ymax: These are set to the minimum and maximum values of x and y in the dataframe, and then snapped to the nearest integer if they are between 1e-4 of an integer.
- pixcountx & pixcounty: pixcountx is set to a default value of 256, and pixcounty is set to preserve the aspect ratio of the underlying data.