### PR TITLE
1D Cross-Sections over 2D Data

### DIFF
--- a/sarracen/__init__.py
+++ b/sarracen/__init__.py
@@ -3,3 +3,5 @@ from sarracen.io.read_marisa import read_marisa
 from sarracen.io.read_csv import read_csv
 
 from sarracen.sarracen_dataframe import SarracenDataFrame
+
+from sarracen.interpolate import interpolate2DCross

--- a/sarracen/interpolate.py
+++ b/sarracen/interpolate.py
@@ -46,7 +46,7 @@ def interpolate2D(data: SarracenDataFrame,
 
     image = np.zeros((pixcounty, pixcountx))
 
-    # iterate through all pixels
+    # iterate through all particles
     for i, particle in data.iterrows():
         # dimensionless weight
         # w_i = m_i / (rho_i * (h_i) ** 2)
@@ -102,3 +102,96 @@ def interpolate2D(data: SarracenDataFrame,
                 image[jpix][ipix] += term * wab
 
     return image
+
+
+def interpolate2DCross(data: SarracenDataFrame,
+                       x: str,
+                       y: str,
+                       target: str,
+                       kernel: BaseKernel,
+                       x1: float,
+                       y1: float,
+                       x2: float,
+                       y2: float,
+                       pixcount: int):
+    if np.isclose(y2, y1) and np.isclose(x2, x1):
+        raise ValueError('Zero length cross section!')
+
+    if pixcount <= 0:
+        raise ValueError('pixcount must be greater than zero!')
+
+    if kernel.ndims != 2:
+        raise ValueError("Kernel must be two-dimensional!")
+
+    output = np.zeros(pixcount)
+
+    gradient = 0
+    if not np.isclose(x2, x1):
+        gradient = (y2 - y1) / (x2 - x1)
+    yint = y2 - gradient * x2
+
+    xlength = np.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
+    pixwidth = xlength / pixcount
+    xpixwidth = (x2 - x1) / pixcount
+
+    # iterate through all particles
+    for i, particle in data.iterrows():
+        # dimensionless weight
+        # w_i = m_i / (rho_i * (h_i) ** 2)
+        weight = particle['m'] / (particle['rho'] * particle['h'] ** 2)
+
+        if weight <= 0:
+            continue
+
+        radkern = kernel.radkernel * particle['h']
+        term = weight * particle[target]
+        hi1 = 1 / particle['h']
+
+        aa = 1 + gradient**2
+        bb = 2 * gradient * (yint - particle[y]) - 2 * particle[x]
+        cc = particle[x] ** 2 - particle[y] ** 2 - 2 * yint * particle[y] + yint ** 2 - radkern**2
+
+        determinant = bb**2 - 4*aa*cc
+        if determinant > 0:
+            det = np.sqrt(determinant)
+            xstart = (-bb - det) / (2 * aa)
+            xend = (-bb + det) / (2 * aa)
+
+            if xstart < x1:
+                xstart = x1
+            if xstart > x2:
+                xstart = x2
+            if xend < x1:
+                xend = x1
+            if xend > x2:
+                xend = x2
+
+            ystart = gradient*xstart + yint
+            yend = gradient*xend + yint
+
+            rstart = np.sqrt((xstart-x1)**2 + (ystart-y1)**2)
+            rend = np.sqrt((xend-x1)**2 + (yend-y1)**2)
+
+            ipixmin = int(np.rint(rstart/pixwidth))
+            ipixmax = int(np.rint(rend/pixwidth))
+
+            if ipixmin < 0:
+                ipixmin = 0
+            if ipixmax < 0:
+                ipixmax = 0
+            if ipixmin > pixcount:
+                ipixmin = pixcount
+            if ipixmax > pixcount:
+                ipixmax = pixcount
+
+            for ipix in range(ipixmin, ipixmax):
+                xpix = x1 + (ipix+0.5)*xpixwidth
+                ypix = gradient*xpix + yint
+                dy = ypix - particle[y]
+                dx = xpix - particle[x]
+                q2 = (dx*dx + dy*dy)*hi1*hi1
+
+                wab = kernel.w(np.sqrt(q2))
+                output[ipix] += term * wab
+
+    return output

--- a/sarracen/kernels/base_kernel.py
+++ b/sarracen/kernels/base_kernel.py
@@ -18,8 +18,6 @@ class BaseKernel:
         :param q: The value of q to evaluate this kernel at.
         :return:
         """
-        if q < 0:
-            raise ValueError('q cannot be lower than 0.')
 
         return self._cnormk * self._wfunc(q)
 

--- a/sarracen/kernels/cubic_spline.py
+++ b/sarracen/kernels/cubic_spline.py
@@ -17,9 +17,4 @@ class CubicSplineKernel(BaseKernel):
 
     @staticmethod
     def _weight(q):
-        if q < 1:
-            return 1 - (3. / 2.) * q ** 2 + (3. / 4.) * q ** 3
-        elif q < 2:
-            return (1. / 4.) * (2 - q) ** 3
-        else:
-            return 0
+        return (1 - (3. / 2.) * q ** 2 + (3. / 4.) * q ** 3) * (q < 1) + (1. / 4.) * (2 - q) ** 3 * (q < 2) * (q >= 1)

--- a/sarracen/kernels/quartic_spline.py
+++ b/sarracen/kernels/quartic_spline.py
@@ -17,11 +17,4 @@ class QuarticSplineKernel(BaseKernel):
 
     @staticmethod
     def _weight(q):
-        if q < 0.5:
-            return ((5 / 2) - q) ** 4 - 5 * ((3 / 2) - q) ** 4 + 10 * ((1 / 2) - q) ** 4
-        elif q < 1.5:
-            return ((5 / 2) - q) ** 4 - 5 * ((3 / 2) - q) ** 4
-        elif q < 2.5:
-            return ((5 / 2) - q) ** 4
-        else:
-            return 0
+        return ((5 / 2) - q) ** 4 * (q < 2.5) - 5 * ((3 / 2) - q) ** 4 * (q < 1.5) + 10 * ((1 / 2) - q) ** 4 * (q < 0.5)

--- a/sarracen/kernels/quintic_spline.py
+++ b/sarracen/kernels/quintic_spline.py
@@ -17,11 +17,4 @@ class QuinticSplineKernel(BaseKernel):
 
     @staticmethod
     def _weight(q):
-        if q < 1:
-            return (3 - q) ** 5 - 6 * (2 - q) ** 5 + 15 * (1 - q) ** 5
-        elif q < 2:
-            return (3 - q) ** 5 - 6 * (2 - q) ** 5
-        elif q < 3:
-            return (3 - q) ** 5
-        else:
-            return 0
+        return (3 - q) ** 5 * (q < 3) - 6 * (2 - q) ** 5 * (q < 2) + 15 * (1 - q) ** 5 * (q < 1)

--- a/sarracen/tests/test_interpolate.py
+++ b/sarracen/tests/test_interpolate.py
@@ -4,7 +4,7 @@ from pytest import approx
 
 from sarracen import SarracenDataFrame
 from sarracen.kernels import CubicSplineKernel
-from sarracen.interpolate import interpolate2D
+from sarracen.interpolate import interpolate2D, interpolate2DCross
 
 
 def test_interpolate2d():
@@ -22,3 +22,27 @@ def test_interpolate2d():
     assert image[20][0] == approx(CubicSplineKernel(2).w(np.sqrt((-1.95) ** 2 + 0.05 ** 2)), rel=1e-8)
     assert image[20][20] == approx(CubicSplineKernel(2).w(np.sqrt(0.05 ** 2 + 0.05 ** 2)), rel=1e-8)
     assert image[12][17] == approx(CubicSplineKernel(2).w(np.sqrt(0.75 ** 2 + 0.25 ** 2)), rel=1e-8)
+
+
+def test_interpolate2dcross():
+    df = df = pd.DataFrame({'x': [0],
+                            'y': [0],
+                            'P': [1],
+                            'h': [1],
+                            'rho': [1],
+                            'm': [1]})
+    sdf = SarracenDataFrame(df, params=dict())
+
+    # first, test a cross-section at y=0
+    output = interpolate2DCross(sdf, 'x', 'y', 'P', CubicSplineKernel(2), -2, 0, 2, 0, 40)
+
+    assert output[0] == approx(CubicSplineKernel(2).w(np.sqrt((-1.95) ** 2)), rel=1e-8)
+    assert output[20] == approx(CubicSplineKernel(2).w(np.sqrt(0.05 ** 2)), rel=1e-8)
+    assert output[17] == approx(CubicSplineKernel(2).w(np.sqrt(0.25 ** 2)), rel=1e-8)
+
+    # next, test a cross-section where x=y
+    output = interpolate2DCross(sdf, 'x', 'y', 'P', CubicSplineKernel(2), -2, -2, 2, 2, 40)
+
+    assert output[0] == approx(CubicSplineKernel(2).w(np.sqrt(2*(1.95 ** 2))), rel=1e-8)
+    assert output[20] == approx(CubicSplineKernel(2).w(np.sqrt(2*(0.05 ** 2))), rel=1e-8)
+    assert output[17] == approx(CubicSplineKernel(2).w(np.sqrt(2*(0.25 ** 2))), rel=1e-8)


### PR DESCRIPTION
Adds a new interpolation function `interpolate2DCross` to `interpolate.py`, which enables interpolation of 2D data inside a `SarracenDataFrame` over a one dimensional line.

Sample:
![image](https://user-images.githubusercontent.com/71343838/167684301-577afe04-920e-4e3a-bd4b-0e6c2a077d2b.png)
```
output = interpolate2DCross(df, 'x', 'y', 'colour', QuinticSplineKernel(2), 0.4, 0, 0.6, 2, 500)

fig, ax = plt.subplots()
sns.lineplot(x=np.linspace(0, np.sqrt(2**2 + 0.4**2), 500), y=output, ax=ax)
plt.show()
```

New unit tests in `test_interpolate.py` have been included for this functionality.