### PR TITLE
Extend SarracenDataFrame to accept 3-dimensional data

### DIFF
--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -36,9 +36,6 @@ class SarracenDataFrame(DataFrame):
         self._units = None
         self.units = Series([np.nan for i in range(len(self.columns))])
 
-        if 'massoftype' in self.params:
-            self['m'] = self.params['massoftype']
-
         self._identify_spacial_columns()
         self._identify_spacial_bounds()
 
@@ -62,7 +59,7 @@ class SarracenDataFrame(DataFrame):
         else:
             self._ycol = self.columns[1]
 
-        # First look for 'z', then 'rz', and then assume that data is 2 dimensional
+        # First look for 'z', then 'rz', and then assume that data is 2 dimensional.
         if 'z' in self.columns:
             self._zcol = 'z'
         elif 'rz' in self.columns:
@@ -86,10 +83,23 @@ class SarracenDataFrame(DataFrame):
             self._zmin = _snap(self.loc[:, self._zcol].min())
             self._zmax = _snap(self.loc[:, self._zcol].max())
 
+    def create_mass_column(self):
+        """
+        Create a new column in this dataframe 'm', which is copied
+        from the 'massoftype' parameter.
+        Intended for use with Phantom data dumps.
+        :return:
+        """
+        if 'massoftype' not in self.params:
+            raise ValueError("'massoftype' column does not exist in this SarracenDataFrame.")
+
+        self['m'] = self.params['massoftype']
+
     def derive_density(self):
         """
         Create a new column in this dataframe 'rho', derived from
         the existing columns 'hfact', 'h', and 'm'.
+        Intended for use with Phantom data dumps.
         """
         if not {'h', 'm'}.issubset(self.columns) or 'hfact' not in self.params:
             raise ValueError('Density cannot be derived from the columns in this SarracenDataFrame.')

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -64,9 +64,9 @@ class SarracenDataFrame(DataFrame):
 
         # First look for 'z', then 'rz', and then assume that data is 2 dimensional
         if 'z' in self.columns:
-            self._zcol = 'y'
+            self._zcol = 'z'
         elif 'rz' in self.columns:
-            self._zcol = 'ry'
+            self._zcol = 'rz'
         else:
             self._zcol = None
 

--- a/sarracen/tests/test_sarracen_dataframe.py
+++ b/sarracen/tests/test_sarracen_dataframe.py
@@ -16,21 +16,25 @@ def test_position():
     assert sdf.xcol == 'x'
     assert sdf.ycol == 'y'
 
-    # The 'rx' and 'ry' keywords should be detected.
+    # The 'rx', 'ry', and 'rz' keywords should be detected.
     df = pd.DataFrame({'ry': [-1, 1],
                        'h': [1, 1],
                        'rho': [1, 1],
                        'rx': [3, 4],
                        'P': [1, 1],
+                       'rz': [4, 3],
                        'm': [1, 1]})
     sdf = SarracenDataFrame(df)
 
     assert sdf.xcol == 'rx'
     assert sdf.ycol == 'ry'
+    assert sdf.zcol == 'rz'
 
     # No keywords, so fall back to the first two columns.
+    # Even though 'k' exists, this will be assumed to be 2D data.
     df = pd.DataFrame({'i': [3.4, 2.1],
                        'j': [4.9, 1.6],
+                       'k': [2.3, 2.0],
                        'h': [1, 1],
                        'rho': [1, 1],
                        'P': [1, 1],
@@ -39,11 +43,13 @@ def test_position():
 
     assert sdf.xcol == 'i'
     assert sdf.ycol == 'j'
+    assert sdf.zcol is None
 
 
 def test_snap():
     df = pd.DataFrame({'x': [0.0001, 5.2],
                        'y': [3.00004, 0.1],
+                       'z': [1.2, 9.00003],
                        'P': [1, 1],
                        'h': [1, 1],
                        'rho': [1, 1],
@@ -58,3 +64,40 @@ def test_snap():
     assert sdf.ymin == 0.1
     # 3.00004 -> 3.0
     assert sdf.ymax == 3.0
+    # 1.2 -> 1.2
+    assert sdf.zmin == 1.2
+    # 9.00003 -> 9
+    assert sdf.zmax == 9
+
+def test_dimensions():
+    # This should be detected as 3-dimensional data.
+    df = pd.DataFrame({'P': [1, 1],
+                       'z': [4, 3],
+                       'h': [1, 1],
+                       'rho': [1, 1],
+                       'x': [5, 6],
+                       'y': [5, 4],
+                       'm': [1, 1]})
+    sdf = SarracenDataFrame(df)
+
+    assert sdf.get_dim() == 3
+
+    # This should be detected as 2-dimensional data.
+    df = pd.DataFrame({'P': [1, 1],
+                       'h': [1, 1],
+                       'y': [5, 4],
+                       'rho': [1, 1],
+                       'm': [1, 1],
+                       'x': [5, 6]})
+    sdf = SarracenDataFrame(df)
+
+    assert sdf.get_dim() == 2
+
+    # This should assumed to be 2-dimensional data.
+    df = pd.DataFrame({'P': [1, 1],
+                       'h': [1, 1],
+                       'rho': [1, 1],
+                       'm': [1, 1]})
+    sdf = SarracenDataFrame(df)
+
+    assert sdf.get_dim() == 2


### PR DESCRIPTION
Includes functionality in SarracenDataFrame to detect 3-dimensional data vs 2-dimensional data. As well, helper methods for Phantom data are included to derive values for mass and density.

Test cases have been included to test dimensionality detection.