### PR TITLE
Rendering for 1D cross-sections

### DIFF
--- a/sarracen/__init__.py
+++ b/sarracen/__init__.py
@@ -5,4 +5,4 @@ from sarracen.io.read_phantom import read_phantom
 
 from sarracen.sarracen_dataframe import SarracenDataFrame
 
-from sarracen.interpolate import interpolate2DCross
+from sarracen.interpolate import interpolate1DCross

--- a/sarracen/interpolate.py
+++ b/sarracen/interpolate.py
@@ -97,7 +97,7 @@ def interpolate2D(data: 'SarracenDataFrame',
     return image
 
 
-def interpolate2DCross(data: SarracenDataFrame,
+def interpolate1DCross(data: 'SarracenDataFrame',
                        x: str,
                        y: str,
                        target: str,

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -4,7 +4,7 @@ from matplotlib.colors import Colormap
 from pandas import DataFrame, Series
 import numpy as np
 
-from sarracen.render import render
+from sarracen.render import render_2d, render_1d_cross
 from sarracen.kernels import CubicSplineKernel, BaseKernel
 
 
@@ -106,7 +106,7 @@ class SarracenDataFrame(DataFrame):
 
         self['rho'] = (self.params['hfact'] / self['h']) ** (self.get_dim()) * self['m']
 
-    def render(self,
+    def render_2d(self,
                target: str,
                x: str = None,
                y: str = None,
@@ -135,7 +135,34 @@ class SarracenDataFrame(DataFrame):
         :return: The completed plot.
         """
 
-        return render(self, target, x, y, kernel, xmin, ymin, xmax, ymax, pixcountx, pixcounty, cmap)
+        return render_2d(self, target, x, y, kernel, xmin, ymin, xmax, ymax, pixcountx, pixcounty, cmap)
+
+    def render_1d_cross(self,
+                       target: str,
+                       x: str = None,
+                       y: str = None,
+                       kernel: BaseKernel = CubicSplineKernel(2),
+                       x1: float = None,
+                       y1: float = None,
+                       x2: float = None,
+                       y2: float = None,
+                       pixcount: int = 500) -> ('Figure', 'Axes'):
+        """
+        Render the data within this SarracenDataFrame to a 1D matplotlib object, by taking a 1D SPH
+        cross-section of the target variable along a given line.
+        :param data: The SarracenDataFrame to render. [Required]
+        :param target: The variable to interpolate over. [Required]
+        :param x: The positional x variable.
+        :param y: The positional y variable.
+        :param kernel: The kernel to use for smoothing the target data.
+        :param x1: The starting x-coordinate of the cross-section line. (in particle data space)
+        :param y1: The starting y-coordinate of the cross-section line. (in particle data space)
+        :param x2: The ending x-coordinate of the cross-section line. (in particle data space)
+        :param y2: The ending y-coordinate of the cross-section line. (in particle data space)
+        :param pixcount: The number of pixels in the output over the entire cross-sectional line.
+        :return: The completed plot.
+        """
+        return render_1d_cross(self, target, x, y, kernel, x1, y1, x2, y2, pixcount)
 
     @property
     def params(self):

--- a/sarracen/tests/test_interpolate.py
+++ b/sarracen/tests/test_interpolate.py
@@ -4,7 +4,7 @@ from pytest import approx
 
 from sarracen import SarracenDataFrame
 from sarracen.kernels import CubicSplineKernel
-from sarracen.interpolate import interpolate2D, interpolate2DCross
+from sarracen.interpolate import interpolate2D, interpolate1DCross
 
 
 def test_interpolate2d():
@@ -24,7 +24,7 @@ def test_interpolate2d():
     assert image[12][17] == approx(CubicSplineKernel(2).w(np.sqrt(0.75 ** 2 + 0.25 ** 2)), rel=1e-8)
 
 
-def test_interpolate2dcross():
+def test_interpolate1dcross():
     df = df = pd.DataFrame({'x': [0],
                             'y': [0],
                             'P': [1],
@@ -34,14 +34,14 @@ def test_interpolate2dcross():
     sdf = SarracenDataFrame(df, params=dict())
 
     # first, test a cross-section at y=0
-    output = interpolate2DCross(sdf, 'x', 'y', 'P', CubicSplineKernel(2), -2, 0, 2, 0, 40)
+    output = interpolate1DCross(sdf, 'x', 'y', 'P', CubicSplineKernel(2), -2, 0, 2, 0, 40)
 
     assert output[0] == approx(CubicSplineKernel(2).w(np.sqrt((-1.95) ** 2)), rel=1e-8)
     assert output[20] == approx(CubicSplineKernel(2).w(np.sqrt(0.05 ** 2)), rel=1e-8)
     assert output[17] == approx(CubicSplineKernel(2).w(np.sqrt(0.25 ** 2)), rel=1e-8)
 
     # next, test a cross-section where x=y
-    output = interpolate2DCross(sdf, 'x', 'y', 'P', CubicSplineKernel(2), -2, -2, 2, 2, 40)
+    output = interpolate1DCross(sdf, 'x', 'y', 'P', CubicSplineKernel(2), -2, -2, 2, 2, 40)
 
     assert output[0] == approx(CubicSplineKernel(2).w(np.sqrt(2*(1.95 ** 2))), rel=1e-8)
     assert output[20] == approx(CubicSplineKernel(2).w(np.sqrt(2*(0.05 ** 2))), rel=1e-8)

--- a/sarracen/tests/test_render.py
+++ b/sarracen/tests/test_render.py
@@ -1,14 +1,14 @@
 import pandas as pd
 import numpy as np
-from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
 from sarracen import SarracenDataFrame
 from sarracen.kernels import CubicSplineKernel
+from sarracen.render import render_2d, render_1d_cross
 
 
-def test_plot_properties():
+def test_2d_plot():
     df = pd.DataFrame({'x': [3, 6],
                        'y': [5, 1],
                        'P': [1, 1],
@@ -17,7 +17,7 @@ def test_plot_properties():
                        'm': [1, 1]})
     sdf = SarracenDataFrame(df)
 
-    fig, ax = sdf.render('P')
+    fig, ax = sdf.render_2d('P')
 
     assert isinstance(fig, Figure)
     assert isinstance(ax, Axes)
@@ -37,3 +37,51 @@ def test_plot_properties():
     # therefore closest pixel is => sqrt((3/512)**2, (2/341)**2)
     # use default kernel to determine the max pressure value
     assert fig.axes[1].get_ylim() == (0, CubicSplineKernel(2).w(np.sqrt((3/512)**2 + (2/341)**2)))
+
+
+def test_1dcross_plot():
+    df = pd.DataFrame({'rx': [0, 5],
+                       'P': [1, 1],
+                       'h': [1, 1],
+                       'rho': [1, 1],
+                       'y': [0, 4],
+                       'm': [1, 1]})
+    sdf = SarracenDataFrame(df)
+
+    fig, ax = sdf.render_1d_cross('P')
+
+    assert isinstance(fig, Figure)
+    assert isinstance(ax, Axes)
+
+    assert ax.get_xlabel() == 'cross-section (rx, y)'
+    assert ax.get_ylabel() == 'P'
+
+    # cross section from (0, 0) -> (5, 4), therefore x goes from 0 -> sqrt(5**2 + 4**2)
+    assert ax.get_xlim() == (0, np.sqrt(41))
+    # 1000 pixels across, and both particles are in corners
+    # therefore closest pixel to a particle is sqrt(41)/1000 units away
+    # use default kernel to determine the max pressure value
+    assert ax.get_ylim() == (0, CubicSplineKernel(2).w(np.sqrt(41) / 1000))
+
+
+def test_render_passthrough():
+    # Basic tests that both sdf.render() and render(sdf) return the same plots
+    df = pd.DataFrame({'x': [3, 6],
+                       'y': [5, 1],
+                       'P': [1, 1],
+                       'h': [1, 1],
+                       'rho': [1, 1],
+                       'm': [1, 1]})
+    sdf = SarracenDataFrame(df)
+
+    fig1, ax1 = sdf.render_2d('P')
+    fig2, ax2 = render_2d(sdf, 'P')
+
+    assert repr(fig1) == repr(fig2)
+    assert repr(ax1) == repr(ax2)
+
+    fig1, ax1 = sdf.render_1d_cross('P')
+    fig2, ax2 = render_1d_cross(sdf, 'P')
+
+    assert repr(fig1) == repr(fig2)
+    assert repr(ax1) == repr(ax2)


### PR DESCRIPTION
Adds a new rendering function to return a matplotlib/seaborn figure & axes containing a 1D cross-section plot of a provided variable. Like 2D rendering, several variables can be tuned by the user, or automatically selected based on some selection rules.

By default, these arguments are selected very similarly as for 2D rendering:
- x & y: First look for the keywords 'x' and 'y' or 'rx' and 'ry' in the columns. If these are not found, fallback to the first two columns.
- kernel: A CubicSplineKernel is chosen by default.
- x1, y1, x2, y2: These are set to the minimum and maximum values of x and y detected in the data.
- pixcount: Set to 400 pixels across by default.

Sample of a produced cross-sectional plot:
![image](https://user-images.githubusercontent.com/71343838/168347312-cca99dcb-0a5c-4b57-a57c-2918eae07baf.png)
