### PR TITLE
3D Column Rendering

### DIFF
--- a/sarracen/kernels/base_kernel.py
+++ b/sarracen/kernels/base_kernel.py
@@ -1,5 +1,9 @@
 from typing import Callable
 
+import numpy as np
+from numba import jit
+from scipy.integrate import quad
+
 
 class BaseKernel:
     """A generic kernel used for data interpolation."""
@@ -16,3 +20,25 @@ class BaseKernel:
         """
 
         return 1
+
+    def get_column_kernel(self, samples):
+        """
+        Generate a 2D column kernel approximation, by integrating a given 3D kernel over the z-axis.
+        :param kernel: The 3D kernel to integrate over.
+        :param samples: The number of samples to take of the integral.
+        :return: A ndarray of length (samples), containing the kernel approximation.
+        """
+        results = []
+        for sample in np.linspace(0, self.get_radius(), samples):
+            results.append(2 * quad(self._int_func,
+                                    a=0,
+                                    b=np.sqrt(self.get_radius() ** 2 - sample ** 2),
+                                    args=(sample, self.w))[0])
+
+        return np.array(results)
+
+    # Internal function for performing the integral in _get_column_kernel()
+    @staticmethod
+    @jit(fastmath=True)
+    def _int_func(q, a, wfunc):
+        return wfunc(np.sqrt(q ** 2 + a ** 2), 3)

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -60,7 +60,7 @@ def render_2d(data: 'SarracenDataFrame',
 
     pixwidthx = (xmax - xmin) / pixcountx
     pixwidthy = (ymax - ymin) / pixcounty
-    image = interpolate3D(data, x, y, data.zcol, target, kernel, pixwidthx, pixwidthy, xmin, ymin, pixcountx, pixcounty)
+    image = interpolate2DCross(data, x, y, target, kernel, pixwidthx, pixwidthy, xmin, ymin, pixcountx, pixcounty)
 
     # ensure the plot size maintains the aspect ratio of the underlying bounds of the data
     fig, ax = plt.subplots(figsize=(6.4, 4.8 * ((ymax - ymin) / (xmax - xmin))))
@@ -121,5 +121,71 @@ def render_1d_cross(data: 'SarracenDataFrame',
     sns.lineplot(x=np.linspace(0, np.sqrt((x2 - x1) ** 2+ (y2 - y1) ** 2), pixcount), y=output, ax=ax)
     ax.set_xlabel(f'cross-section ({x}, {y})')
     ax.set_ylabel(target)
+
+    return fig, ax
+
+
+def render_3d(data: 'SarracenDataFrame',
+              target: str,
+              x: str = None,
+              y: str = None,
+              kernel: BaseKernel = CubicSplineKernel(),
+              xmin: float = None,
+              ymin: float = None,
+              xmax: float = None,
+              ymax: float = None,
+              pixcountx: int = 256,
+              pixcounty: int = None,
+              cmap: Union[str, Colormap] = 'RdBu',
+              int_samples: int = 1000) -> ('Figure', 'Axes'):
+    """
+    Render the data within a SarracenDataFrame to a 2D matplotlib object, using 3D -> 2D column interpolation of the
+    target variable.
+    :param data: The SarracenDataFrame to render. [Required]
+    :param target: The variable to interpolate over. [Required]
+    :param x: The positional x variable.
+    :param y: The positional y variable.
+    :param kernel: The smoothing kernel to use for interpolation.
+    :param xmin: The minimum bound in the x-direction.
+    :param ymin: The minimum bound in the y-direction.
+    :param xmax: The maximum bound in the x-direction.
+    :param ymax: The maximum bound in the y-direction.
+    :param pixcountx: The number of pixels in the x-direction.
+    :param pixcounty: The number of pixels in the y-direction.
+    :param cmap: The color map to use for plotting this data.
+    :param int_samples: The number of samples to use when approximating the kernel column integral.
+    :return: The completed plot.
+    """
+    # x & y columns default to the variables determined by the SarracenDataFrame.
+    if x is None:
+        x = data.xcol
+    if y is None:
+        y = data.ycol
+
+    # plot bounds default to variable determined in SarracenDataFrame
+    if xmin is None:
+        xmin = data.xmin
+    if ymin is None:
+        ymin = data.ymin
+    if xmax is None:
+        xmax = data.xmax
+    if ymax is None:
+        ymax = data.ymax
+
+    # set pixcounty to maintain an aspect ratio that is the same as the underlying bounds of the data.
+    if pixcounty is None:
+        pixcounty = int(np.rint(pixcountx * ((ymax - ymin) / (xmax - xmin))))
+
+    pixwidthx = (xmax - xmin) / pixcountx
+    pixwidthy = (ymax - ymin) / pixcounty
+    img = interpolate3D(data, x, y, target, kernel, pixwidthx, pixwidthy, xmin, ymin, pixcountx, pixcounty, int_samples)
+
+    # ensure the plot size maintains the aspect ratio of the underlying bounds of the data
+    fig, ax = plt.subplots(figsize=(6.4, 4.8 * ((ymax - ymin) / (xmax - xmin))))
+    graphic = ax.imshow(img, cmap=cmap, origin='lower', extent=[xmin, xmax, ymin, ymax])
+    ax.set_xlabel(x)
+    ax.set_ylabel(y)
+    cbar = fig.colorbar(graphic, ax=ax)
+    cbar.ax.set_ylabel(f"column {target}")
 
     return fig, ax

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -5,7 +5,7 @@ from matplotlib import pyplot as plt
 from matplotlib.colors import Colormap
 import seaborn as sns
 
-from sarracen.interpolate import interpolate2DCross, interpolate1DCross
+from sarracen.interpolate import interpolate2DCross, interpolate1DCross, interpolate3D
 from sarracen.kernels import BaseKernel, CubicSplineKernel
 
 
@@ -60,7 +60,7 @@ def render_2d(data: 'SarracenDataFrame',
 
     pixwidthx = (xmax - xmin) / pixcountx
     pixwidthy = (ymax - ymin) / pixcounty
-    image = interpolate2DCross(data, x, y, target, kernel, pixwidthx, pixwidthy, xmin, ymin, pixcountx, pixcounty)
+    image = interpolate3D(data, x, y, data.zcol, target, kernel, pixwidthx, pixwidthy, xmin, ymin, pixcountx, pixcounty)
 
     # ensure the plot size maintains the aspect ratio of the underlying bounds of the data
     fig, ax = plt.subplots(figsize=(6.4, 4.8 * ((ymax - ymin) / (xmax - xmin))))

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -4,7 +4,7 @@ from matplotlib.colors import Colormap
 from pandas import DataFrame, Series
 import numpy as np
 
-from sarracen.render import render_2d, render_1d_cross
+from sarracen.render import render_2d, render_1d_cross, render_3d
 from sarracen.kernels import CubicSplineKernel, BaseKernel
 
 
@@ -105,6 +105,39 @@ class SarracenDataFrame(DataFrame):
             raise ValueError('Density cannot be derived from the columns in this SarracenDataFrame.')
 
         self['rho'] = (self.params['hfact'] / self['h']) ** (self.get_dim()) * self['m']
+
+    def render_3d(self,
+               target: str,
+               x: str = None,
+               y: str = None,
+               kernel: BaseKernel = CubicSplineKernel(),
+               xmin: float = None,
+               ymin: float = None,
+               xmax: float = None,
+               ymax: float = None,
+               pixcountx: int = 256,
+               pixcounty: int = None,
+               cmap: Union[str, Colormap] = 'RdBu',
+               int_samples: int = 1000) -> ('Figure', 'Axes'):
+        """
+        Render the data within this dataframe to a 2D matplotlib object, using 3D -> 2D column interpolation of the
+        target variable.
+        :param target: The variable to interpolate over. [Required]
+        :param x: The positional x variable.
+        :param y: The positional y variable.
+        :param kernel: The smoothing kernel to use for interpolation.
+        :param xmin: The minimum bound in the x-direction.
+        :param ymin: The minimum bound in the y-direction.
+        :param xmax: The maximum bound in the x-direction.
+        :param ymax: The maximum bound in the y-direction.
+        :param pixcountx: The number of pixels in the x-direction.
+        :param pixcounty: The number of pixels in the y-direction.
+        :param cmap: The color map to use for plotting this data.
+        :param int_samples: The number of samples to use when approximating the kernel column integral.
+        :return: The completed plot.
+        """
+
+        return render_3d(self, target, x, y, kernel, xmin, ymin, xmax, ymax, pixcountx, pixcounty, cmap, int_samples)
 
     def render_2d(self,
                target: str,

--- a/sarracen/tests/test_interpolate.py
+++ b/sarracen/tests/test_interpolate.py
@@ -1,12 +1,11 @@
 import pandas as pd
 import numpy as np
 from matplotlib import pyplot as plt
-import seaborn as sns
 from pytest import approx
 
 from sarracen import SarracenDataFrame
 from sarracen.kernels import CubicSplineKernel
-from sarracen.interpolate import interpolate2DCross, interpolate1DCross, interpolate3DCross
+from sarracen.interpolate import interpolate2DCross, interpolate1DCross, interpolate3DCross, interpolate3D
 
 
 def test_interpolate2d():
@@ -45,9 +44,10 @@ def test_interpolate1dcross():
     # next, test a cross-section where x=y
     output = interpolate1DCross(sdf, 'x', 'y', 'P', CubicSplineKernel(), -2, -2, 2, 2, 40)
 
-    assert output[0] == approx(CubicSplineKernel().w(np.sqrt(2*(1.95 ** 2)), 2), rel=1e-8)
-    assert output[20] == approx(CubicSplineKernel().w(np.sqrt(2*(0.05 ** 2)), 2), rel=1e-8)
-    assert output[17] == approx(CubicSplineKernel().w(np.sqrt(2*(0.25 ** 2)), 2), rel=1e-8)
+    assert output[0] == approx(CubicSplineKernel().w(np.sqrt(2 * (1.95 ** 2)), 2), rel=1e-8)
+    assert output[20] == approx(CubicSplineKernel().w(np.sqrt(2 * (0.05 ** 2)), 2), rel=1e-8)
+    assert output[17] == approx(CubicSplineKernel().w(np.sqrt(2 * (0.25 ** 2)), 2), rel=1e-8)
+
 
 def test_interpolate3dcross():
     df = df = pd.DataFrame({'x': [0],
@@ -75,3 +75,25 @@ def test_interpolate3dcross():
     assert image[20][0] == approx(CubicSplineKernel().w(np.sqrt((-1.95) ** 2 + 0.05 ** 2 + (0.5 ** 2)), 2), rel=1e-8)
     assert image[20][20] == approx(CubicSplineKernel().w(np.sqrt(2 * (0.05 ** 2) + (0.5 ** 2)), 2), rel=1e-8)
     assert image[12][17] == approx(CubicSplineKernel().w(np.sqrt(0.75 ** 2 + 0.25 ** 2 + (0.5 ** 2)), 2), rel=1e-8)
+
+
+def test_interpolate3d():
+    df = pd.DataFrame({'x': [0.25],
+                       'y': [0.25],
+                       'z': [0],
+                       'P': [0.5],
+                       'h': [0.125],
+                       'rho': [0.5],
+                       'm': [0.01],
+                       'A': [3]})
+    sdf = SarracenDataFrame(df, params=dict())
+
+    image = interpolate3D(sdf, 'x', 'y', 'A', CubicSplineKernel(), 0.05, 0.05, 0, 0, 10, 10, 10000)
+
+    # w = 0.01 / (0.5 * 0.125^3) = 10.24
+
+    assert image[0][0] == 0
+    # 10.24 * 0.125 * 3 * F(sqrt(0.025^2 + 0.225^2)/0.125) ~= 3.84 * 0.000409322579272
+    assert image[0][4] == approx(0.0015718842, rel=1e-4)
+    # 10.24 * 0.125 * 3 * F(sqrt(0.025^2 + 0.025^2)/0.125) ~= 3.84 * 0.427916515256
+    assert image[5][5] == approx(1.6431994186, rel=1e-4)

--- a/sarracen/tests/test_interpolate.py
+++ b/sarracen/tests/test_interpolate.py
@@ -62,19 +62,19 @@ def test_interpolate3dcross():
     # first, test a cross-section at z=0
     image = interpolate3DCross(sdf, 'x', 'y', 'z', 'P', CubicSplineKernel(), 0, 0.1, 0.1, -2, -2, 40, 40)
 
-    # should be exactly the same as for a 2D rendering
+    # should be exactly the same as for a 2D rendering, except q values are now taken from the 3D kernel.
     assert image[0][0] == 0
-    assert image[20][0] == approx(CubicSplineKernel().w(np.sqrt((-1.95) ** 2 + 0.05 ** 2), 2), rel=1e-8)
-    assert image[20][20] == approx(CubicSplineKernel().w(np.sqrt(0.05 ** 2 + 0.05 ** 2), 2), rel=1e-8)
-    assert image[12][17] == approx(CubicSplineKernel().w(np.sqrt(0.75 ** 2 + 0.25 ** 2), 2), rel=1e-8)
+    assert image[20][0] == approx(CubicSplineKernel().w(np.sqrt((-1.95) ** 2 + 0.05 ** 2), 3), rel=1e-8)
+    assert image[20][20] == approx(CubicSplineKernel().w(np.sqrt(0.05 ** 2 + 0.05 ** 2), 3), rel=1e-8)
+    assert image[12][17] == approx(CubicSplineKernel().w(np.sqrt(0.75 ** 2 + 0.25 ** 2), 3), rel=1e-8)
 
     # next, test a cross-section at z=0.5
     image = interpolate3DCross(sdf, 'x', 'y', 'z', 'P', CubicSplineKernel(), 0.5, 0.1, 0.1, -2, -2, 40, 40)
 
     assert image[0][0] == 0
-    assert image[20][0] == approx(CubicSplineKernel().w(np.sqrt((-1.95) ** 2 + 0.05 ** 2 + (0.5 ** 2)), 2), rel=1e-8)
-    assert image[20][20] == approx(CubicSplineKernel().w(np.sqrt(2 * (0.05 ** 2) + (0.5 ** 2)), 2), rel=1e-8)
-    assert image[12][17] == approx(CubicSplineKernel().w(np.sqrt(0.75 ** 2 + 0.25 ** 2 + (0.5 ** 2)), 2), rel=1e-8)
+    assert image[20][0] == approx(CubicSplineKernel().w(np.sqrt((-1.95) ** 2 + 0.05 ** 2 + (0.5 ** 2)), 3), rel=1e-8)
+    assert image[20][20] == approx(CubicSplineKernel().w(np.sqrt(2 * (0.05 ** 2) + (0.5 ** 2)), 3), rel=1e-8)
+    assert image[12][17] == approx(CubicSplineKernel().w(np.sqrt(0.75 ** 2 + 0.25 ** 2 + (0.5 ** 2)), 3), rel=1e-8)
 
 
 def test_interpolate3d():

--- a/sarracen/tests/test_kernels.py
+++ b/sarracen/tests/test_kernels.py
@@ -100,3 +100,44 @@ class TestKernels:
         for kernel in [CubicSplineKernel(), QuarticSplineKernel(), QuinticSplineKernel()]:
             norm = tplquad(triple_kernel, 0, kernel.get_radius(), 0, kernel.get_radius(), 0, kernel.get_radius(), [kernel])[0]
             assert approx(norm) == 0.125  # positive space -> an eight of 3D space
+
+    def test_column_integration(self):
+        kernel = CubicSplineKernel()
+        column_kernel = kernel.get_column_kernel(10000)
+
+        # at q = 0, this integral is solvable analytically
+        assert np.interp(0, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == approx(3 / (2 * np.pi))
+        # numerically calculated values
+        assert np.interp(0.5, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == approx(0.33875339978)
+        assert np.interp(1, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == approx(0.111036060968)
+        assert np.interp(1.5, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == approx(0.0114423169642)
+        assert np.interp(2, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == 0
+        assert np.interp(5, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == 0
+
+        kernel = QuarticSplineKernel()
+        column_kernel = kernel.get_column_kernel(10000)
+
+        # at q = 0, this integral is solvable analytically
+        assert np.interp(0, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == approx(6 / (5 * np.pi))
+        # numerically calculated values
+        assert np.interp(0.5, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == approx(0.288815941868)
+        assert np.interp(1, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == approx(0.120120735858)
+        assert np.interp(1.5, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == approx(0.0233911861393)
+        assert np.interp(2, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == approx(0.00116251851966)
+        assert np.interp(2.5, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == 0
+        assert np.interp(5, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == 0
+
+        kernel = QuinticSplineKernel()
+        column_kernel = kernel.get_column_kernel(10000)
+
+        # at q = 0, this integral is solvable analytically
+        assert np.interp(0, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == approx(1 / np.pi)
+        # numerically calculated values
+        assert np.interp(0.5, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == approx(0.251567608959)
+        assert np.interp(1, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == approx(0.121333261458)
+        assert np.interp(1.5, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == approx(0.0328632154395)
+        assert np.interp(2, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == approx(0.00403036583315)
+        assert np.interp(2.5, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == approx(0.0000979416858548,
+                                                                                                   rel=1e-4)
+        assert np.interp(3, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == 0
+        assert np.interp(5, np.linspace(0, kernel.get_radius(), 10000), column_kernel) == 0


### PR DESCRIPTION
Adds a new interpolation function `interpolate3DCross`, which interpolates a target variable in a 3-dimensional SarracenDataFrame to a 2D grid, by interpolating along columns in the z-direction.

In addition to the 3D column interpolation function, a new render function `render_3d` has been added to both SarracenDataFrame and `render.py`, which produces a matplotlib figure containing an image/colorbar with information obtained from `interpolate3DCross`.

Sample:
![image](https://user-images.githubusercontent.com/71343838/169374882-7389a527-257d-4085-bd04-4199811f2f50.png)

Test cases have been included for both the 3D column interpolation & render functions.

A hotfix for the 3D -> 1D cross section unit test has also been included.