### PR TITLE
Add render function for 3D->2D cross-sections

### DIFF
--- a/sarracen/interpolate.py
+++ b/sarracen/interpolate.py
@@ -228,25 +228,60 @@ def interpolate3DCross(data: 'SarracenDataFrame',
                        ymin: float = 0,
                        pixcountx: int = 480,
                        pixcounty: int = 480):
-    """
-    Interpolates particle data in a SarracenDataFrame across three directional axes to a 2D
-    cross-sectional slice of pixels at a fixed z-value.
+    """ Interpolate 3D particle data to a 2D grid, using a 3D cross-section.
 
-    :param data: The particle data, in a SarracenDataFrame.
-    :param x: The column label of the x-directional axis.
-    :param y: The column label of the y-directional axis.
-    :param z: The column label of the z-directional axis.
-    :param target: The column label of the target smoothing data.
-    :param kernel: The kernel to use for smoothing the target data.
-    :param zslice: The z-axis value to take the cross-section value at.
-    :param pixwidthx: The width that each pixel represents in particle data space.
-    :param pixwidthy: The height that each pixel represents in particle data space.
-    :param xmin: The starting x-coordinate (in particle data space).
-    :param ymin: The starting y-coordinate (in particle data space).
-    :param pixcountx: The number of pixels in the output image in the x-direction.
-    :param pixcounty: The number of pixels in the output image in the y-direction.
-    :return: The output image, in a 2-dimensional numpy array.
+    Interpolates particle data in a SarracenDataFrame across three directional axes to a 2D
+    grid of pixels. A cross-section is taken of the 3D data at a specific value of z, and
+    the contributions of particles near the plane are interpolated to a 2D grid.
+
+    Parameters
+    ----------
+    data : SarracenDataFrame
+        The particle data to interpolate over.
+    x: str
+        The column label of the x-directional axis.
+    y: str
+        The column label of the y-directional axis.
+    z: str
+        The column label of the z-directional axis.
+    target: str
+        The column label of the target smoothing data.
+    kernel: BaseKernel
+        The kernel to use for smoothing the target data.
+    zslice: float
+        The z-axis value to take the cross-section at.
+    pixwidthx: float
+        The width that each pixel represents in particle data space.
+    pixwidthy: float
+        The height that each pixel represents in particle data space.
+    xmin: float, optional
+        The starting x-coordinate (in particle data space).
+    ymin: float, optional
+        The starting y-coordinate (in particle data space).
+    pixcountx: int, optional
+        The number of pixels in the output image in the x-direction.
+    pixcounty: int, optional
+        The number of pixels in the output image in the y-direction.
+
+    Returns
+    -------
+    ndarray
+        The interpolated output image, in a 2-dimensional numpy array. Dimensions are
+        structured in reverse order, where (x, y) -> [y][x]
+
+    Raises
+    -------
+    ValueError
+        If `pixwidthx`, `pixwidthy`, `pixcountx`, or `pixcounty` are less than or equal to zero.
     """
+    if pixwidthx <= 0:
+        raise ValueError("pixwidthx must be greater than zero!")
+    if pixwidthy <= 0:
+        raise ValueError("pixwidthy must be greater than zero!")
+    if pixcountx <= 0:
+        raise ValueError("pixcountx must be greater than zero!")
+    if pixcounty <= 0:
+        raise ValueError("pixcounty must be greater than zero!")
 
     return _fast_interpolate3d_cross(data[x].to_numpy(),
                                      data[y].to_numpy(),
@@ -267,24 +302,24 @@ def interpolate3DCross(data: 'SarracenDataFrame',
 
 
 # Underlying numba-compiled code for 3D->2D cross-sections
-@numba.jit(nopython=True, parallel=True, fastmath=True)
+# @numba.jit(nopython=True, parallel=True, fastmath=True)
 def _fast_interpolate3d_cross(xterm, yterm, zterm, wfunc, zslice, kernrad, target, mass, rho, h, pixwidthx, pixwidthy,
                               xmin, ymin, pixcountx, pixcounty):
     # Filter out particles that do not contribute to this cross-section slice
-    term = target * mass / (rho * h ** 2)
+    term = target * mass / (rho * h ** 3)
     dz = zslice - zterm
-    filter_distance = dz ** 2 * (1 / h ** 2) < kernrad * 2
+    filter_distance = np.abs(dz) < kernrad * h
 
-    ipixmin = np.rint((xterm[filter_distance] - kernrad * h[filter_distance] - xmin) / pixwidthx).clip(a_min=0,
-                                                                                                       a_max=pixcountx)
-    jpixmin = np.rint((yterm[filter_distance] - kernrad * h[filter_distance] - ymin) / pixwidthy).clip(a_min=0,
-                                                                                                       a_max=pixcounty)
-    ipixmax = np.rint((xterm[filter_distance] + kernrad * h[filter_distance] - xmin) / pixwidthx).clip(a_min=0,
-                                                                                                       a_max=pixcountx)
-    jpixmax = np.rint((yterm[filter_distance] + kernrad * h[filter_distance] - ymin) / pixwidthy).clip(a_min=0,
-                                                                                                       a_max=pixcounty)
+    ipixmin = np.rint((xterm[filter_distance] - kernrad * h[filter_distance] - xmin) / pixwidthx).clip(min=0,
+                                                                                                       max=pixcountx)
+    jpixmin = np.rint((yterm[filter_distance] - kernrad * h[filter_distance] - ymin) / pixwidthy).clip(min=0,
+                                                                                                       max=pixcounty)
+    ipixmax = np.rint((xterm[filter_distance] + kernrad * h[filter_distance] - xmin) / pixwidthx).clip(min=0,
+                                                                                                       max=pixcountx)
+    jpixmax = np.rint((yterm[filter_distance] + kernrad * h[filter_distance] - ymin) / pixwidthy).clip(min=0,
+                                                                                                       max=pixcounty)
 
-    image = np.zeros((pixcountx, pixcounty))
+    image = np.zeros((pixcounty, pixcountx))
 
     for i in prange(len(xterm[filter_distance])):
         # precalculate differences in the x-direction

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -5,7 +5,7 @@ from matplotlib import pyplot as plt
 from matplotlib.colors import Colormap
 import seaborn as sns
 
-from sarracen.interpolate import interpolate2DCross, interpolate1DCross, interpolate3D
+from sarracen.interpolate import interpolate2DCross, interpolate1DCross, interpolate3D, interpolate3DCross
 from sarracen.kernels import BaseKernel, CubicSplineKernel
 
 
@@ -118,9 +118,114 @@ def render_1d_cross(data: 'SarracenDataFrame',
 
     fig, ax = plt.subplots()
     ax.margins(x=0, y=0)
-    sns.lineplot(x=np.linspace(0, np.sqrt((x2 - x1) ** 2+ (y2 - y1) ** 2), pixcount), y=output, ax=ax)
+    sns.lineplot(x=np.linspace(0, np.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2), pixcount), y=output, ax=ax)
     ax.set_xlabel(f'cross-section ({x}, {y})')
     ax.set_ylabel(target)
+
+    return fig, ax
+
+
+def render_3d_cross(data: 'SarracenDataFrame',
+                    target: str,
+                    zslice: float = None,
+                    x: str = None,
+                    y: str = None,
+                    z: str = None,
+                    kernel: BaseKernel = CubicSplineKernel(),
+                    xmin: float = None,
+                    ymin: float = None,
+                    xmax: float = None,
+                    ymax: float = None,
+                    pixcountx: int = 480,
+                    pixcounty: int = None,
+                    cmap: Union[str, Colormap] = 'RdBu') -> tuple['Figure', 'Axes']:
+    """ Render 3D particle data to a 2D grid, using a 3D cross-section.
+
+    Render the data within a SarracenDataFrame to a 2D matplotlib object, using a 3D -> 2D
+    cross-section of the target variable. The cross-section is taken of the 3D data at a specific
+    value of z, and the contributions of particles near the plane are interpolated to a 2D grid.
+
+    Parameters
+    ----------
+    data : SarracenDataFrame
+        The particle data, in a SarracenDataFrame.
+    target: str
+        The column label of the target smoothing data.
+    zslice: float
+        The z-axis value to take the cross-section at.
+    x: str
+        The column label of the x-directional axis.
+    y: str
+        The column label of the y-directional axis.
+    z: str
+        The column label of the z-directional axis.
+    kernel: BaseKernel
+        The kernel to use for smoothing the target data.
+    xmin: float, optional
+        The minimum bound in the x-direction. (in particle data space)
+    ymin: float, optional
+        The minimum bound in the y-direction. (in particle data space)
+    xmax: float, optional
+        The maximum bound in the x-direction. (in particle data space)
+    ymax: float, optional
+        The maximum bound in the y-direction. (in particle data space)
+    pixcountx: int, optional
+        The number of pixels in the output image in the x-direction.
+    pixcounty: int, optional
+        The number of pixels in the output image in the y-direction.
+    cmap: str or Colormap, optional
+        The color map to use when plotting this data.
+
+    Returns
+    -------
+    Figure
+        The resulting matplotlib figure, containing the 3d-cross section and
+        a color bar indicating the magnitude of the target variable.
+    Axes
+        The resulting matplotlib axes, which contains the 3d-cross section image.
+
+    Raises
+    -------
+    ValueError
+        If `pixwidthx`, `pixwidthy`, `pixcountx`, or `pixcounty` are less than or equal to zero.
+    """
+    # x & y columns default to the variables determined by the SarracenDataFrame.
+    if x is None:
+        x = data.xcol
+    if y is None:
+        y = data.ycol
+    if z is None:
+        z = data.zcol
+
+    # plot bounds default to variables determined in SarracenDataFrame
+    if xmin is None:
+        xmin = data.xmin
+    if ymin is None:
+        ymin = data.ymin
+    if xmax is None:
+        xmax = data.xmax
+    if ymax is None:
+        ymax = data.ymax
+
+    # set default slice to be through the middle of the data's z-axis.
+    if zslice is None:
+        zslice = (data.zmin + data.zmax) / 2
+
+    # set pixcounty to maintain an aspect ratio that is the same as the underlying bounds of the data.
+    if pixcounty is None:
+        pixcounty = int(np.rint(pixcountx * ((ymax - ymin) / (xmax - xmin))))
+
+    pixwidthx = (xmax - xmin) / pixcountx
+    pixwidthy = (ymax - ymin) / pixcounty
+    img = interpolate3DCross(data, x, y, z, target, kernel, zslice, pixwidthx, pixwidthy, xmin, ymin, pixcountx, pixcounty)
+
+    # ensure the plot size maintains the aspect ratio of the underlying bounds of the data
+    fig, ax = plt.subplots(figsize=(6.4, 4.8 * ((ymax - ymin) / (xmax - xmin))))
+    graphic = ax.imshow(img, cmap=cmap, origin='lower', extent=[xmin, xmax, ymin, ymax])
+    ax.set_xlabel(x)
+    ax.set_ylabel(y)
+    cbar = fig.colorbar(graphic, ax=ax)
+    cbar.ax.set_ylabel(f"{target}")
 
     return fig, ax
 

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -4,7 +4,7 @@ from matplotlib.colors import Colormap
 from pandas import DataFrame, Series
 import numpy as np
 
-from sarracen.render import render_2d, render_1d_cross, render_3d
+from sarracen.render import render_2d, render_1d_cross, render_3d, render_3d_cross
 from sarracen.kernels import CubicSplineKernel, BaseKernel
 
 
@@ -196,6 +196,70 @@ class SarracenDataFrame(DataFrame):
         :return: The completed plot.
         """
         return render_1d_cross(self, target, x, y, kernel, x1, y1, x2, y2, pixcount)
+
+    def render_3d_cross(self,
+                        target: str,
+                        zslice: float = None,
+                        x: str = None,
+                        y: str = None,
+                        z: str = None,
+                        kernel: BaseKernel = CubicSplineKernel(),
+                        xmin: float = None,
+                        ymin: float = None,
+                        xmax: float = None,
+                        ymax: float = None,
+                        pixcountx: int = 480,
+                        pixcounty: int = None,
+                        cmap: Union[str, Colormap] = 'RdBu') -> ('Figure', 'Axes'):
+        """ Render 3D particle data inside this DataFrame to a 2D grid, using a 3D cross-section.
+
+        Render the data within this SarracenDataFrame to a 2D matplotlib object, using a 3D -> 2D
+        cross-section of the target variable. The cross-section is taken of the 3D data at a specific
+        value of z, and the contributions of particles near the plane are interpolated to a 2D grid.
+
+        Parameters
+        ----------
+        target: str
+            The column label of the target smoothing data.
+        zslice: float
+            The z-axis value to take the cross-section at.
+        x: str
+            The column label of the x-directional axis.
+        y: str
+            The column label of the y-directional axis.
+        z: str
+            The column label of the z-directional axis.
+        kernel: BaseKernel
+            The kernel to use for smoothing the target data.
+        xmin: float, optional
+            The minimum bound in the x-direction. (in particle data space)
+        ymin: float, optional
+            The minimum bound in the y-direction. (in particle data space)
+        xmax: float, optional
+            The maximum bound in the x-direction. (in particle data space)
+        ymax: float, optional
+            The maximum bound in the y-direction. (in particle data space)
+        pixcountx: int, optional
+            The number of pixels in the output image in the x-direction.
+        pixcounty: int, optional
+            The number of pixels in the output image in the y-direction.
+        cmap: str or Colormap, optional
+            The color map to use when plotting this data.
+
+        Returns
+        -------
+        Figure
+            The resulting matplotlib figure, containing the 3d-cross section and
+            a color bar indicating the magnitude of the target variable.
+        Axes
+            The resulting matplotlib axes, which contains the 3d-cross section image.
+
+        Raises
+        -------
+        ValueError
+           If `pixwidthx`, `pixwidthy`, `pixcountx`, or `pixcounty` are less than or equal to zero.
+        """
+        return render_3d_cross(self, target, zslice, x, y, z, kernel, xmin, ymin, xmax, ymax, pixcountx, pixcounty, cmap)
 
     @property
     def params(self):

--- a/sarracen/tests/test_render.py
+++ b/sarracen/tests/test_render.py
@@ -6,7 +6,7 @@ from pytest import approx
 
 from sarracen import SarracenDataFrame
 from sarracen.kernels import CubicSplineKernel
-from sarracen.render import render_2d, render_1d_cross, render_3d
+from sarracen.render import render_2d, render_1d_cross, render_3d, render_3d_cross
 
 
 def test_2d_plot():
@@ -93,12 +93,42 @@ def test_3d_plot():
     assert fig.axes[1].get_ylim() == (0, approx(0.477372919027))
 
 
+def test_3dcross_plot():
+    df = pd.DataFrame({'rx': [0, 2.5, 5],
+                       'P': [1, 1, 1],
+                       'h': [1, 1, 1],
+                       'rz': [3, 2, 1],
+                       'rho': [1, 1, 1],
+                       'y': [0, 2, 4],
+                       'm': [1, 1, 1]})
+    sdf = SarracenDataFrame(df)
+
+    # setting the pixel count to an odd number ensures that the middle particle at (2.5, 2, 2) is at the
+    # exact same position as the centre pixel.
+    fig, ax = sdf.render_3d_cross('P', pixcountx=489)
+
+    assert isinstance(fig, Figure)
+    assert isinstance(ax, Axes)
+
+    assert ax.get_xlabel() == 'rx'
+    assert ax.get_ylabel() == 'y'
+    # the colorbar is contained in a second axes object inside the figure
+    assert fig.axes[1].get_ylabel() == 'P'
+
+    assert ax.get_xlim() == (0, 5)
+    assert ax.get_ylim() == (0, 4)
+
+    # closest pixel/particle pair comes from the particle at (2.5, 2, 2), with r = 0.
+    assert fig.axes[1].get_ylim() == (0, approx(CubicSplineKernel().w(0, 3)))
+
+
 def test_render_passthrough():
     # Basic tests that both sdf.render() and render(sdf) return the same plots
     df = pd.DataFrame({'x': [3, 6],
                        'y': [5, 1],
                        'P': [1, 1],
                        'h': [1, 1],
+                       'z': [6, 3],
                        'rho': [1, 1],
                        'm': [1, 1]})
     sdf = SarracenDataFrame(df)
@@ -117,6 +147,12 @@ def test_render_passthrough():
 
     fig1, ax1 = sdf.render_3d('P')
     fig2, ax2 = render_3d(sdf, 'P')
+
+    assert repr(fig1) == repr(fig2)
+    assert repr(ax1) == repr(ax2)
+
+    fig1, ax1 = sdf.render_3d_cross('P')
+    fig2, ax2 = render_3d_cross(sdf, 'P')
 
     assert repr(fig1) == repr(fig2)
     assert repr(ax1) == repr(ax2)


### PR DESCRIPTION
Add a new rendering function `render_3d_cross`, to both `render.py` and `SarracenDataFrame`. This function returns a matplotlib figure & axes containing a 3d->2d cross-sectional plot of a 3d particle dataset.

Sample of a 3d->2d cross-sectional plot:
![image](https://user-images.githubusercontent.com/71343838/170119482-1925f73b-67f6-4e8c-9339-a5ab23625086.png)

Documentation and unit tests are also included for this new function.