### PR TITLE
Use trapezoid rule for calculating 3D column kernels

### DIFF
--- a/sarracen/interpolate.py
+++ b/sarracen/interpolate.py
@@ -389,6 +389,8 @@ def _fast_3d(target, x_data, y_data, mass_data, rho_data, h_data, integrated_ker
     ipixmax = np.rint((x_data + kernel_rad * h_data - x_min) / pixwidthx).clip(a_min=0, a_max=x_pixels)
     jpixmax = np.rint((y_data + kernel_rad * h_data - y_min) / pixwidthy).clip(a_min=0, a_max=y_pixels)
 
+    sample_space = np.linspace(0, kernel_rad, int_samples)
+
     # iterate through the indexes of non-filtered particles
     for i in prange(len(term)):
         # precalculate differences in the x-direction (optimization)
@@ -402,7 +404,7 @@ def _fast_3d(target, x_data, y_data, mass_data, rho_data, h_data, integrated_ker
 
         # calculate contributions at pixels i, j due to particle at x, y
         q2 = dx2i + dy2.reshape(len(dy2), 1)
-        wab = np.interp(np.sqrt(q2), np.linspace(0, kernel_rad, int_samples), integrated_kernel)
+        wab = np.interp(np.sqrt(q2), sample_space, integrated_kernel)
 
         # add contributions to image
         image[int(jpixmin[i]):int(jpixmax[i]), int(ipixmin[i]):int(ipixmax[i])] += (wab * term[i])

--- a/sarracen/kernels/base_kernel.py
+++ b/sarracen/kernels/base_kernel.py
@@ -1,12 +1,13 @@
-from typing import Callable
-
 import numpy as np
-from numba import jit
-from scipy.integrate import quad
+from numba import njit, prange
 
 
 class BaseKernel:
     """A generic kernel used for data interpolation."""
+
+    def __init__(self):
+        self._column_cache = None
+
     @staticmethod
     def get_radius() -> float:
         """Get the smoothing radius of this kernel."""
@@ -31,7 +32,7 @@ class BaseKernel:
 
         return 1
 
-    def get_column_kernel(self, samples: int) -> np.ndarray:
+    def get_column_kernel(self, samples: int = 1000) -> np.ndarray:
         """ Generate a 2D column kernel approximation, by integrating a given 3D kernel over the z-axis.
 
         Parameters
@@ -48,17 +49,28 @@ class BaseKernel:
         Use np.linspace and np.interp to use this column kernel approximation:
             np.interp(q, np.linspace(0, kernel.get_radius(), samples), column_kernel)
         """
-        results = []
-        for sample in np.linspace(0, self.get_radius(), samples):
-            results.append(2 * quad(self._int_func,
-                                    a=0,
-                                    b=np.sqrt(self.get_radius() ** 2 - sample ** 2),
-                                    args=(sample, self.w))[0])
+        if samples == 1000 and self._column_cache is not None:
+            return self._column_cache
 
-        return np.array(results)
+        c_kernel = self._int_func(self.get_radius(), samples, self.w)
+
+        if samples == 1000:
+            self._column_cache = c_kernel
+
+        return c_kernel
 
     # Internal function for performing the integral in _get_column_kernel()
     @staticmethod
-    @jit(fastmath=True)
-    def _int_func(q, a, wfunc):
-        return wfunc(np.sqrt(q ** 2 + a ** 2), 3)
+    @njit(fastmath=True, parallel=True)
+    def _int_func(radius, samples, wfunc):
+        result = np.zeros(samples)
+
+        for i in prange(samples):
+            q_xy = radius * i / (samples - 1)
+            bounds = np.sqrt(radius ** 2 - q_xy ** 2)
+            q_z = np.linspace(0, bounds, samples)
+            q = np.sqrt(q_xy ** 2 + q_z ** 2)
+            y = wfunc(q, 3)
+            result[i] = 2 * np.trapz(y, x=q_z)
+
+        return result


### PR DESCRIPTION
Switch out the use of scipy's `quad` function in favour of `np.trapz` for calculating the 2D interpolated form of the 3D kernel for 3D column integration. As well, the default 1000 sample kernel is cached upon calculation.
This change has the greatest effect on interpolating datasets with low numbers of particles, with a 2x speedup observed on low-particle datasets.