### PR TITLE
Rotations for 3D interpolation & rendering functions

### DIFF
--- a/sarracen/interpolate.py
+++ b/sarracen/interpolate.py
@@ -309,13 +309,21 @@ def interpolate_3d(data: 'SarracenDataFrame',
     x: str
         Column label of the x-directional axis.
     y: str
-        The column label of the y-directional axis.
+        Column label of the y-directional axis.
+    z: str
+        Column label of the z-directional axis.
     target: str
-        The column label of the target smoothing data.
+        Column label of the target smoothing data.
     kernel: BaseKernel
-        The kernel to use for smoothing the target data.
+        Kernel to use for smoothing the target data.
     integral_samples: int, optional
-        The number of sample points to take when approximating the 2D column kernel.
+        Number of sample points to take when approximating the 2D column kernel.
+    rotation: array_like, optional
+        Defines the rotation in degrees to apply to the data before interpolation. The
+        order of rotations is [z, y, x].
+    origin: array_like, optional
+        Point of rotation of the data, in [x, y, z] form. Defaults to the centre
+        point of the bounds of the data.
     x_pixels: int, optional
         Number of pixels in the output image in the x-direction.
     y_pixels: int, optional
@@ -386,9 +394,9 @@ def interpolate_3d(data: 'SarracenDataFrame',
         if origin is None:
             origin = (vectors[:, 0].min() + vectors[:, 0].max()) / 2
 
-        vectors -= origin
+        vectors = vectors - origin
         vectors = rot.apply(vectors)
-        vectors += origin
+        vectors = vectors + origin
 
         x_data = vectors[:, 0]
         y_data = vectors[:, 1]
@@ -458,8 +466,6 @@ def interpolate_3d_cross(data: 'SarracenDataFrame',
 
     Parameters
     ----------
-    rotation
-    origin
     data : SarracenDataFrame
         The particle data to interpolate over.
     target: str
@@ -474,6 +480,12 @@ def interpolate_3d_cross(data: 'SarracenDataFrame',
         The column label of the z-directional axis.
     kernel: BaseKernel
         The kernel to use for smoothing the target data.
+    rotation: array_like, optional
+        Defines the rotation in degrees to apply to the data before interpolation. The
+        order of rotations is [z, y, x].
+    origin: array_like, optional
+        Point of rotation of the data, in [x, y, z] form. Defaults to the centre
+        point of the bounds of the data.
     x_pixels: int, optional
         Number of pixels in the output image in the x-direction.
     y_pixels: int, optional
@@ -541,9 +553,9 @@ def interpolate_3d_cross(data: 'SarracenDataFrame',
         if origin is None:
             origin = (vectors[:, 0].min() + vectors[:, 0].max()) / 2
 
-        vectors -= origin
+        vectors = vectors - origin
         vectors = rot.apply(vectors)
-        vectors += origin
+        vectors = vectors + origin
 
         x_data = vectors[:, 0]
         y_data = vectors[:, 1]

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -273,10 +273,18 @@ def render_3d(data: 'SarracenDataFrame',
         Column label of the x-directional axis. Defaults to the x-column detected in `data`.
     y: str, optional
         Column label of the y-directional axis. Defaults to the y-column detected in `data`.
+    z: str, optional
+        Column label of the z-directional axis. Defaults to the z-column detected in `data`.
     kernel: BaseKernel, optional
         Kernel to use for smoothing the target data. Defaults to the kernel specified in `data`.
     integral_samples: int, optional
         The number of sample points to take when approximating the 2D column kernel.
+    rotation: array_like, optional
+        Defines the rotation in degrees to apply to the data before interpolation. The
+        order of rotations is [z, y, x].
+    origin: array_like, optional
+        Point of rotation of the data, in [x, y, z] form. Defaults to the centre
+        point of the bounds of the data.
     x_pixels: int, optional
         Number of pixels in the output image in the x-direction. If both x_pixels and y_pixels are
         None, this defaults to 256. Otherwise, this value defaults to a multiple of y_pixels which
@@ -315,7 +323,7 @@ def render_3d(data: 'SarracenDataFrame',
         if the specified `x` and `y` minimum and maximums result in an invalid region, or
         if the provided data is not 3-dimensional.
     KeyError
-        If `target`, `x`, `y`, mass, density, or smoothing length columns do not
+        If `target`, `x`, `y`, `z`, mass, density, or smoothing length columns do not
         exist in `data`.
     """
     # x & y columns default to the variables determined by the SarracenDataFrame.
@@ -354,6 +362,8 @@ def render_3d(data: 'SarracenDataFrame',
     fig, ax = plt.subplots(figsize=(6.4, 4.8 * ((y_max - y_min) / (x_max - x_min))))
     graphic = ax.imshow(img, cmap=colormap, origin='lower', extent=[x_min, x_max, y_min, y_max])
 
+    # remove the x & y ticks if the data is rotated, since these no longer have physical
+    # relevance to the displayed data.
     if rotation is not None:
         ax.set_xticks([])
         ax.set_yticks([])
@@ -404,9 +414,15 @@ def render_3d_cross(data: 'SarracenDataFrame',
     y: str, optional
         Column label of the y-directional axis. Defaults to the y-column detected in `data`.
     z: str
-        The column label of the z-directional axis.
+        Column label of the z-directional axis. Defaults to the z-column detected in `data`.
     kernel: BaseKernel, optional
         Kernel to use for smoothing the target data. Defaults to the kernel specified in `data`.
+    rotation: array_like, optional
+        Defines the rotation in degrees to apply to the data before interpolation. The
+        order of rotations is [z, y, x].
+    origin: array_like, optional
+        Point of rotation of the data, in [x, y, z] form. Defaults to the centre
+        point of the bounds of the data.
     x_pixels: int, optional
         Number of pixels in the output image in the x-direction. If both x_pixels and y_pixels are
         None, this defaults to 256. Otherwise, this value defaults to a multiple of y_pixels which
@@ -441,7 +457,12 @@ def render_3d_cross(data: 'SarracenDataFrame',
     Raises
     -------
     ValueError
-        If `pixwidthx`, `pixwidthy`, `pixcountx`, or `pixcounty` are less than or equal to zero.
+        If `pixwidthx`, `pixwidthy`, `pixcountx`, or `pixcounty` are less than or equal to zero, or
+        if the specified `x` and `y` minimum and maximums result in an invalid region, or
+        if the provided data is not 3-dimensional.
+    KeyError
+        If `target`, `x`, `y`, mass, density, or smoothing length columns do not
+        exist in `data`.
     """
     # x & y columns default to the variables determined by the SarracenDataFrame.
     if x is None:
@@ -482,8 +503,16 @@ def render_3d_cross(data: 'SarracenDataFrame',
     # ensure the plot size maintains the aspect ratio of the underlying bounds of the data
     fig, ax = plt.subplots(figsize=(6.4, 4.8 * ((y_max - y_min) / (x_max - x_min))))
     graphic = ax.imshow(img, cmap=colormap, origin='lower', extent=[x_min, x_max, y_min, y_max])
-    ax.set_xlabel(x)
-    ax.set_ylabel(y)
+
+    # remove the x & y ticks if the data is rotated, since these no longer have physical
+    # relevance to the displayed data.
+    if rotation is not None:
+        ax.set_xticks([])
+        ax.set_yticks([])
+    else:
+        ax.set_xlabel(x)
+        ax.set_ylabel(y)
+
     cbar = fig.colorbar(graphic, ax=ax)
     cbar.ax.set_ylabel(f"{target}")
 

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -245,8 +245,11 @@ def render_3d(data: 'SarracenDataFrame',
               target: str,
               x: str = None,
               y: str = None,
+              z: str = None,
               kernel: BaseKernel = None,
               integral_samples: int = 1000,
+              rotation: np.ndarray = None,
+              origin: np.ndarray = None,
               x_pixels: int = None,
               y_pixels: int = None,
               x_min: float = None,
@@ -314,17 +317,14 @@ def render_3d(data: 'SarracenDataFrame',
     KeyError
         If `target`, `x`, `y`, mass, density, or smoothing length columns do not
         exist in `data`.
-
-    Notes
-    -----
-    Since the direction of integration is assumed to be straight across the z-axis, the z-axis column
-    is not required for this type of rendering.
     """
     # x & y columns default to the variables determined by the SarracenDataFrame.
     if x is None:
         x = data.xcol
     if y is None:
         y = data.ycol
+    if z is None:
+        z = data.zcol
 
     # boundaries of the plot default to the maximum & minimum values of the data.
     if x_min is None:
@@ -347,13 +347,20 @@ def render_3d(data: 'SarracenDataFrame',
     if kernel is None:
         kernel = data.kernel
 
-    img = interpolate_3d(data, target, x, y, kernel, integral_samples, x_pixels, y_pixels, x_min, x_max, y_min, y_max)
+    img = interpolate_3d(data, target, x, y, z, kernel, integral_samples, rotation, origin, x_pixels, y_pixels, x_min,
+                         x_max, y_min, y_max)
 
     # ensure the plot size maintains the aspect ratio of the underlying bounds of the data
     fig, ax = plt.subplots(figsize=(6.4, 4.8 * ((y_max - y_min) / (x_max - x_min))))
     graphic = ax.imshow(img, cmap=colormap, origin='lower', extent=[x_min, x_max, y_min, y_max])
-    ax.set_xlabel(x)
-    ax.set_ylabel(y)
+
+    if rotation is not None:
+        ax.set_xticks([])
+        ax.set_yticks([])
+    else:
+        ax.set_xlabel(x)
+        ax.set_ylabel(y)
+
     cbar = fig.colorbar(graphic, ax=ax)
     cbar.ax.set_ylabel(f"column {target}")
 
@@ -367,6 +374,8 @@ def render_3d_cross(data: 'SarracenDataFrame',
                     y: str = None,
                     z: str = None,
                     kernel: BaseKernel = None,
+                    rotation: np.ndarray = None,
+                    origin: np.ndarray = None,
                     x_pixels: int = None,
                     y_pixels: int = None,
                     x_min: float = None,
@@ -382,6 +391,8 @@ def render_3d_cross(data: 'SarracenDataFrame',
 
     Parameters
     ----------
+    rotation
+    origin
     data : SarracenDataFrame
         Particle data, in a SarracenDataFrame.
     target: str
@@ -465,7 +476,8 @@ def render_3d_cross(data: 'SarracenDataFrame',
     if y_pixels is None:
         y_pixels = int(np.rint(x_pixels * ((y_max - y_min) / (x_max - x_min))))
 
-    img = interpolate_3d_cross(data, target, z_slice, x, y, z, kernel, x_pixels, y_pixels, x_min, x_max, y_min, y_max)
+    img = interpolate_3d_cross(data, target, z_slice, x, y, z, kernel, rotation, origin, x_pixels, y_pixels, x_min,
+                               x_max, y_min, y_max)
 
     # ensure the plot size maintains the aspect ratio of the underlying bounds of the data
     fig, ax = plt.subplots(figsize=(6.4, 4.8 * ((y_max - y_min) / (x_max - x_min))))

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -3,6 +3,7 @@ from typing import Union, Callable
 from matplotlib.colors import Colormap
 from pandas import DataFrame, Series
 import numpy as np
+from scipy.spatial.transform import Rotation as R
 
 from sarracen.render import render_2d, render_2d_cross, render_3d, render_3d_cross
 from sarracen.kernels import CubicSplineKernel, BaseKernel
@@ -178,8 +179,11 @@ class SarracenDataFrame(DataFrame):
                   target: str,
                   x: str = None,
                   y: str = None,
+                  z: str = None,
                   kernel: BaseKernel = None,
                   int_samples: int = 1000,
+                  rotation: np.ndarray = None,
+                  origin: np.ndarray = None,
                   x_pixels: int = None,
                   y_pixels: int = None,
                   x_min: float = None,
@@ -188,7 +192,7 @@ class SarracenDataFrame(DataFrame):
                   y_max: float = None,
                   colormap: Union[str, Colormap] = 'RdBu') -> ('Figure', 'Axes'):
 
-        return render_3d(self, target, x, y, kernel, int_samples, x_pixels, y_pixels, x_min, x_max, y_min, y_max,
+        return render_3d(self, target, x, y, z, kernel, int_samples, rotation, origin, x_pixels, y_pixels, x_min, x_max, y_min, y_max,
                          colormap)
 
     @_copy_doc(render_3d_cross)
@@ -199,6 +203,8 @@ class SarracenDataFrame(DataFrame):
                         y: str = None,
                         z: str = None,
                         kernel: BaseKernel = None,
+                        rotation: np.ndarray = None,
+                        origin: np.ndarray = None,
                         x_pixels: int = None,
                         y_pixels: int = None,
                         x_min: float = None,
@@ -207,8 +213,8 @@ class SarracenDataFrame(DataFrame):
                         y_max: float = None,
                         colormap: Union[str, Colormap] = 'RdBu') -> ('Figure', 'Axes'):
 
-        return render_3d_cross(self, target, z_slice, x, y, z, kernel, x_pixels, y_pixels, x_min, x_max, y_min, y_max,
-                               colormap)
+        return render_3d_cross(self, target, z_slice, x, y, z, kernel, rotation, origin, x_pixels, y_pixels, x_min,
+                               x_max, y_min, y_max, colormap)
 
     @property
     def params(self):

--- a/sarracen/tests/test_interpolate.py
+++ b/sarracen/tests/test_interpolate.py
@@ -105,7 +105,7 @@ def test_interpolate_3d():
     sdf = SarracenDataFrame(df, params=dict())
     kernel = QuarticSplineKernel()
 
-    image = interpolate_3d(sdf, 'A', 'x', 'y', kernel, 10000, 10, 10, 0, 0.5, 0, 0.5)
+    image = interpolate_3d(sdf, 'A', 'x', 'y', 'z', kernel, 10000, None, None, 10, 10, 0, 0.5, 0, 0.5)
     column_kernel = kernel.get_column_kernel(10000)
 
     # w = 0.01 / (0.5 * 0.125^3) = 10.24
@@ -131,7 +131,7 @@ def test_interpolate_3d():
     sdf = SarracenDataFrame(df, params=dict())
     kernel = QuinticSplineKernel()
 
-    image = interpolate_3d(sdf, 'A', 'x', 'y', kernel, 10000, 20, 15, 0, 2, 0, 0.9)
+    image = interpolate_3d(sdf, 'A', 'x', 'y', 'z', kernel, 10000, None, None, 20, 15, 0, 2, 0, 0.9)
     column_kernel = kernel.get_column_kernel(10000)
 
     # w = 0.15 / (0.21 * 1.5^3) = 0.21164
@@ -164,7 +164,8 @@ def test_interpolate_3d_cross():
     sdf = SarracenDataFrame(df, params=dict())
 
     # first, test a cross-section at z=0
-    image = interpolate_3d_cross(sdf, 'P', 0, 'x', 'y', 'z', CubicSplineKernel(), 40, 40, -2, 2, -2, 2)
+    image = interpolate_3d_cross(sdf, 'P', 0, 'x', 'y', 'z', CubicSplineKernel(), None, None, 40, 40, -2, 2, -2,
+                                 2)
 
     # should be exactly the same as for a 2D rendering, except q values are now taken from the 3D kernel.
     assert image[0][0] == 0
@@ -173,7 +174,8 @@ def test_interpolate_3d_cross():
     assert image[12][17] == approx(CubicSplineKernel().w(np.sqrt(0.75 ** 2 + 0.25 ** 2), 3), rel=1e-8)
 
     # next, test a cross-section at z=0.5
-    image = interpolate_3d_cross(sdf, 'P', 0.5, 'x', 'y', 'z', CubicSplineKernel(), 40, 40, -2, 2, -2, 2)
+    image = interpolate_3d_cross(sdf, 'P', 0.5, 'x', 'y', 'z', CubicSplineKernel(), None, None, 40, 40, -2, 2, -2,
+                                 2)
 
     assert image[0][0] == 0
     assert image[20][0] == approx(CubicSplineKernel().w(np.sqrt((-1.95) ** 2 + 0.05 ** 2 + (0.5 ** 2)), 3), rel=1e-8)
@@ -192,7 +194,8 @@ def test_interpolate_3d_cross():
 
     w = sdf['m'][0] / (sdf['rho'][0] * sdf['h'][0] ** 3)
     kernel = QuarticSplineKernel()
-    image = interpolate_3d_cross(sdf, 'A', 0, 'x', 'y', 'z', kernel, 15, 11, -0.75, 0.75, -0.825, 0.825)
+    image = interpolate_3d_cross(sdf, 'A', 0, 'x', 'y', 'z', kernel, None, None, 15, 11, -0.75, 0.75, -0.825,
+                                 0.825)
 
     # r = sqrt(dx ** 2 + dy ** 2 + dz ** 2)
     assert image[0][0] == approx(w * sdf['A'][0] * kernel.w(np.sqrt(0.7 ** 2 + 0.75 ** 2 + 1) / sdf['h'][0], 3))


### PR DESCRIPTION
Adds support to 3D interpolation & rendering functions for data rotation. This enables the user to render 3D data at any desired angle. 

Example of a rotated plot:
![image](https://user-images.githubusercontent.com/71343838/171467368-f4c33cd8-ba66-49ee-941f-80d99ee9cee0.png)

Note that because the data is rotated, the values of the x & y axes no longer have physical relevance to the data. Therefore, the ticks on these axes are removed when the data is rotated.

Rotations are performed as Euler extrinsic rotations, in the order z->y->x (similar to splash). This functionality is provided by the `scipy.spatial.transform` library.

As an example: passing `rotation = [0, 45, 90]` to a 3D interpolation function will first rotate the data 45 degrees about the y-axis, and 90 degrees about the x-axis.