### PR TITLE
Additional arguments and refactoring of interpolation & render functions.

### DIFF
--- a/sarracen/interpolate.py
+++ b/sarracen/interpolate.py
@@ -29,6 +29,110 @@ def _snap(value: float):
         return value
 
 
+def _default_xy(data, x, y):
+    # x & y columns default to the variables determined by the SarracenDataFrame.
+    if x is None:
+        x = data.xcol
+    if y is None:
+        y = data.ycol
+
+    return x, y
+
+
+def _snap_boundaries(data, x, y, x_min, x_max, y_min, y_max):
+    # boundaries of the plot default to the maximum & minimum values of the data.
+    if x_min is None:
+        x_min = _snap(data.loc[:, x].min())
+    if y_min is None:
+        y_min = _snap(data.loc[:, y].min())
+    if x_max is None:
+        x_max = _snap(data.loc[:, x].max())
+    if y_max is None:
+        y_max = _snap(data.loc[:, y].max())
+
+    return x_min, x_max, y_min, y_max
+
+
+def _set_pixels(data, x_pixels, y_pixels, x_min, x_max, y_min, y_max):
+    # set # of pixels to maintain an aspect ratio that is the same as the underlying bounds of the data.
+    if x_pixels is None and y_pixels is None:
+        x_pixels = 512
+    if x_pixels is None:
+        x_pixels = int(np.rint(y_pixels * ((x_max - x_min) / (y_max - y_min))))
+    if y_pixels is None:
+        y_pixels = int(np.rint(x_pixels * ((y_max - y_min) / (x_max - x_min))))
+
+    return x_pixels, y_pixels
+
+
+def _verify_columns(data, target, x, y):
+    if x not in data.columns:
+        raise KeyError(f"x-directional column '{x}' does not exist in the provided dataset.")
+    if y not in data.columns:
+        raise KeyError(f"x-directional column '{y}' does not exist in the provided dataset.")
+    if target not in data.columns:
+        raise KeyError(f"Target column '{target}' does not exist in provided dataset.")
+    if data.mcol is None:
+        raise KeyError("Mass column does not exist in the provided dataset, please create it with "
+                       "sdf.create_mass_column().")
+    if data.rhocol is None:
+        raise KeyError("Density column does not exist in the provided dataset, please create it with"
+                       "sdf.derive_density().")
+    if data.hcol is None:
+        raise KeyError("Smoothing length column does not exist in the provided dataset.")
+
+
+def _default_kernel(data, kernel):
+    if kernel is None:
+        return data.kernel
+    return kernel
+
+
+def _check_boundaries(x_pixels, y_pixels, x_min, x_max, y_min, y_max):
+    if x_max - x_min <= 0:
+        raise ValueError("`xmax` must be greater than `xmin`!")
+    if y_max - y_min <= 0:
+        raise ValueError("`ymax` must be greater than `ymin`!")
+    if x_pixels <= 0:
+        raise ValueError("`x_pixels` must be greater than zero!")
+    if y_pixels <= 0:
+        raise ValueError("`y_pixels` must be greater than zero!")
+
+
+def _check_dimension(data, dim):
+    if data.get_dim() != dim:
+        raise ValueError(f"Dataset is not {dim}-dimensional.")
+
+
+def _rotate_data(data, x, y, z, rotation, origin):
+    x_data = data[x].to_numpy()
+    y_data = data[y].to_numpy()
+    z_data = data[z].to_numpy()
+    if rotation is not None:
+        if not isinstance(rotation, Rotation):
+            rotation = R.from_euler('zyx', rotation, degrees=True)
+
+        vectors = data[[data.xcol, data.ycol, data.zcol]].to_numpy()
+        if origin is None:
+            origin = (vectors[:, 0].min() + vectors[:, 0].max()) / 2
+
+        vectors = vectors - origin
+        vectors = rotation.apply(vectors)
+        vectors = vectors + origin
+
+        x_data = vectors[:, 0] if x == data.xcol else \
+            vectors[:, 1] if x == data.ycol else \
+                vectors[:, 2] if x == data.zcol else x_data
+        y_data = vectors[:, 0] if y == data.xcol else \
+            vectors[:, 1] if y == data.ycol else \
+                vectors[:, 2] if y == data.zcol else y_data
+        z_data = vectors[:, 0] if z == data.xcol else \
+            vectors[:, 1] if z == data.ycol else \
+                vectors[:, 2] if z == data.zcol else z_data
+
+    return x_data, y_data, z_data
+
+
 def interpolate_2d(data: 'SarracenDataFrame',
                    target: str,
                    x: str = None,
@@ -85,101 +189,19 @@ def interpolate_2d(data: 'SarracenDataFrame',
         If `target`, `x`, `y`, mass, density, or smoothing length columns do not
         exist in `data`.
     """
-    # x & y columns default to the variables determined by the SarracenDataFrame.
-    if x is None:
-        x = data.xcol
-    if y is None:
-        y = data.ycol
+    x, y = _default_xy(data, x, y)
+    _verify_columns(data, x, y, target)
 
-    # boundaries of the plot default to the maximum & minimum values of the data.
-    if x_min is None:
-        x_min = _snap(data.loc[:, x].min())
-    if y_min is None:
-        y_min = _snap(data.loc[:, y].min())
-    if x_max is None:
-        x_max = _snap(data.loc[:, x].max())
-    if y_max is None:
-        y_max = _snap(data.loc[:, y].max())
+    x_min, x_max, y_min, y_max = _snap_boundaries(data, x, y, x_min, x_max, y_min, y_max)
+    x_pixels, y_pixels = _set_pixels(data, x_pixels, y_pixels, x_min, x_max, y_min, y_max)
+    _check_boundaries(x_pixels, y_pixels, x_min, x_max, y_min, y_max)
 
-    # set # of pixels to maintain an aspect ratio that is the same as the underlying bounds of the data.
-    if x_pixels is None and y_pixels is None:
-        x_pixels = 512
-    if x_pixels is None:
-        x_pixels = int(np.rint(y_pixels * ((x_max - x_min) / (y_max - y_min))))
-    if y_pixels is None:
-        y_pixels = int(np.rint(x_pixels * ((y_max - y_min) / (x_max - x_min))))
-
-    if kernel is None:
-        kernel = data.kernel
-
-    if x not in data.columns:
-        raise KeyError(f"x-directional column '{x}' does not exist in the provided dataset.")
-    if y not in data.columns:
-        raise KeyError(f"x-directional column '{y}' does not exist in the provided dataset.")
-    if target not in data.columns:
-        raise KeyError(f"Target column '{target}' does not exist in provided dataset.")
-    if data.mcol is None:
-        raise KeyError("Mass column does not exist in the provided dataset, please create it with "
-                       "sdf.create_mass_column().")
-    if data.rhocol is None:
-        raise KeyError("Density column does not exist in the provided dataset, please create it with"
-                       "sdf.derive_density().")
-    if data.hcol is None:
-        raise KeyError("Smoothing length column does not exist in the provided dataset.")
-
-    if x_max - x_min <= 0:
-        raise ValueError("`xmax` must be greater than `xmin`!")
-    if y_max - y_min <= 0:
-        raise ValueError("`ymax` must be greater than `ymin`!")
-    if x_pixels <= 0:
-        raise ValueError("`x_pixels` must be greater than zero!")
-    if y_pixels <= 0:
-        raise ValueError("`y_pixels` must be greater than zero!")
+    kernel = _default_kernel(data, kernel)
+    _check_dimension(data, 2)
 
     return _fast_2d(data[target].to_numpy(), data[x].to_numpy(), data[y].to_numpy(), data['m'].to_numpy(),
                     data['rho'].to_numpy(), data['h'].to_numpy(), kernel.w, kernel.get_radius(), x_pixels,
                     y_pixels, x_min, x_max, y_min, y_max)
-
-
-# Underlying numba-compiled code for 2D interpolation
-@njit(parallel=True, fastmath=True)
-def _fast_2d(target, x_data, y_data, mass_data, rho_data, h_data, weight_function, kernel_radius, x_pixels, y_pixels,
-             x_min, x_max, y_min, y_max):
-    image = np.zeros((y_pixels, x_pixels))
-    pixwidthx = (x_max - x_min) / x_pixels
-    pixwidthy = (y_max - y_min) / y_pixels
-
-    term = (target * mass_data / (rho_data * h_data ** 2))
-
-    # determine maximum and minimum pixels that each particle contributes to
-    ipixmin = np.rint((x_data - kernel_radius * h_data - x_min) / pixwidthx) \
-        .clip(a_min=0, a_max=x_pixels)
-    jpixmin = np.rint((y_data - kernel_radius * h_data - y_min) / pixwidthy) \
-        .clip(a_min=0, a_max=y_pixels)
-    ipixmax = np.rint((x_data + kernel_radius * h_data - x_min) / pixwidthx) \
-        .clip(a_min=0, a_max=x_pixels)
-    jpixmax = np.rint((y_data + kernel_radius * h_data - y_min) / pixwidthy) \
-        .clip(a_min=0, a_max=y_pixels)
-
-    # iterate through the indexes of non-filtered particles
-    for i in prange(len(term)):
-        # precalculate differences in the x-direction (optimization)
-        dx2i = ((x_min + (np.arange(int(ipixmin[i]), int(ipixmax[i])) + 0.5) * pixwidthx - x_data[i]) ** 2) \
-               * (1 / (h_data[i] ** 2))
-
-        # determine differences in the y-direction
-        ypix = y_min + (np.arange(int(jpixmin[i]), int(jpixmax[i])) + 0.5) * pixwidthy
-        dy = ypix - y_data[i]
-        dy2 = dy * dy * (1 / (h_data[i] ** 2))
-
-        # calculate contributions at pixels i, j due to particle at x, y
-        q2 = dx2i + dy2.reshape(len(dy2), 1)
-        wab = weight_function(np.sqrt(q2), 2)
-
-        # add contributions to image
-        image[int(jpixmin[i]):int(jpixmax[i]), int(ipixmin[i]):int(ipixmax[i])] += (wab * term[i])
-
-    return image
 
 
 def interpolate_2d_cross(data: 'SarracenDataFrame',
@@ -236,113 +258,22 @@ def interpolate_2d_cross(data: 'SarracenDataFrame',
         If `target`, `x`, `y`, mass, density, or smoothing length columns do not
         exist in `data`.
     """
-    # x & y columns default to the variables determined by the SarracenDataFrame.
-    if x is None:
-        x = data.xcol
-    if y is None:
-        y = data.ycol
+    x, y = _default_xy(data, x, y)
+    _verify_columns(data, x, y, target)
 
-    # start and end points of the line default to the maximum & minimum values of the data.
-    if x1 is None:
-        x1 = _snap(data.loc[:, x].min())
-    if y1 is None:
-        y1 = _snap(data.loc[:, y].min())
-    if x2 is None:
-        x2 = _snap(data.loc[:, x].max())
-    if y2 is None:
-        y2 = _snap(data.loc[:, y].max())
-
-    if kernel is None:
-        kernel = data.kernel
-
-    if x not in data.columns:
-        raise KeyError(f"x-directional column '{x}' does not exist in the provided dataset.")
-    if y not in data.columns:
-        raise KeyError(f"x-directional column '{y}' does not exist in the provided dataset.")
-    if target not in data.columns:
-        raise KeyError(f"Target column '{target}' does not exist in the provided dataset.")
-    if data.mcol is None:
-        raise KeyError("Mass column does not exist in the provided dataset, please create it with "
-                       "sdf.create_mass_column().")
-    if data.rhocol is None:
-        raise KeyError("Density column does not exist in the provided dataset, please create it with"
-                       "sdf.derive_density().")
-    if data.hcol is None:
-        raise ValueError("Smoothing length column does not exist in the provided dataset.")
-
+    x1, x2, y1, y2 = _snap_boundaries(data, x, y, x1, x2, y1, y2)
     if y2 == y1 and x2 == x1:
         raise ValueError('Zero length cross section!')
+
+    kernel = _default_kernel(data, kernel)
+    _check_dimension(data, 2)
+
     if pixels <= 0:
         raise ValueError('pixcount must be greater than zero!')
 
     return _fast_2d_cross(data[target].to_numpy(), data[x].to_numpy(), data[y].to_numpy(), data['m'].to_numpy(),
                           data['rho'].to_numpy(), data['h'].to_numpy(), kernel.w, kernel.get_radius(), pixels, x1,
                           x2, y1, y2)
-
-
-# Underlying numba-compiled code for 2D->1D cross-sections
-@njit(parallel=True, fastmath=True)
-def _fast_2d_cross(target, x_data, y_data, mass_data, rho_data, h_data, weight_function, kernel_radius, pixels, x1, x2,
-                   y1, y2):
-    # determine the slope of the cross-section line
-    gradient = 0
-    if not x2 - x1 == 0:
-        gradient = (y2 - y1) / (x2 - x1)
-    yint = y2 - gradient * x2
-
-    # determine the fraction of the line that one pixel represents
-    xlength = np.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
-    pixwidth = xlength / pixels
-    xpixwidth = (x2 - x1) / pixels
-
-    term = target * mass_data / (rho_data * h_data ** 2)
-
-    # the intersections between the line and a particle's 'smoothing circle' are
-    # found by solving a quadratic equation with the below values of a, b, and c.
-    # if the determinant is negative, the particle does not contribute to the
-    # cross-section, and can be removed.
-    aa = 1 + gradient ** 2
-    bb = 2 * gradient * (yint - y_data) - 2 * x_data
-    cc = x_data ** 2 + y_data ** 2 - 2 * yint * y_data + yint ** 2 - (kernel_radius * h_data) ** 2
-    det = bb ** 2 - 4 * aa * cc
-
-    # create a filter for particles that do not contribute to the cross-section
-    filter_det = det >= 0
-    det = np.sqrt(det)
-    cc = None
-
-    output = np.zeros(pixels)
-
-    # the starting and ending x coordinates of the lines intersections with a particle's smoothing circle
-    xstart = ((-bb[filter_det] - det[filter_det]) / (2 * aa)).clip(a_min=x1, a_max=x2)
-    xend = ((-bb[filter_det] + det[filter_det]) / (2 * aa)).clip(a_min=x1, a_max=x2)
-    bb, det = None, None
-
-    # the start and end distances which lie within a particle's smoothing circle.
-    rstart = np.sqrt((xstart - x1) ** 2 + ((gradient * xstart + yint) - y1) ** 2)
-    rend = np.sqrt((xend - x1) ** 2 + (((gradient * xend + yint) - y1) ** 2))
-    xstart, xend = None, None
-
-    # the maximum and minimum pixels that each particle contributes to.
-    ipixmin = np.rint(rstart / pixwidth).clip(a_min=0, a_max=pixels)
-    ipixmax = np.rint(rend / pixwidth).clip(a_min=0, a_max=pixels)
-    rstart, rend = None, None
-
-    # iterate through the indices of all non-filtered particles
-    for i in prange(len(x_data[filter_det])):
-        # determine contributions to all affected pixels for this particle
-        xpix = x1 + (np.arange(int(ipixmin[i]), int(ipixmax[i])) + 0.5) * xpixwidth
-        ypix = gradient * xpix + yint
-        dy = ypix - y_data[filter_det][i]
-        dx = xpix - x_data[filter_det][i]
-
-        q2 = (dx * dx + dy * dy) * (1 / (h_data[filter_det][i] * h_data[filter_det][i]))
-        wab = weight_function(np.sqrt(q2), 2)
-
-        # add contributions to output total, transformed by minimum/maximum pixels
-        output[int(ipixmin[i]):int(ipixmax[i])] += (wab * term[filter_det][i])
-
-    return output
 
 
 def interpolate_3d(data: 'SarracenDataFrame',
@@ -418,120 +349,20 @@ def interpolate_3d(data: 'SarracenDataFrame',
     Since the direction of integration is assumed to be straight across the z-axis, the z-axis column
     is not required for this type of interpolation.
     """
-    # x & y columns default to the variables determined by the SarracenDataFrame.
-    if x is None:
-        x = data.xcol
-    if y is None:
-        y = data.ycol
+    x, y = _default_xy(data, x, y)
+    _verify_columns(data, x, y, target)
 
-    # boundaries of the plot default to the maximum & minimum values of the data.
-    if x_min is None:
-        x_min = _snap(data.loc[:, x].min())
-    if y_min is None:
-        y_min = _snap(data.loc[:, y].min())
-    if x_max is None:
-        x_max = _snap(data.loc[:, x].max())
-    if y_max is None:
-        y_max = _snap(data.loc[:, y].max())
+    x_min, x_max, y_min, y_max = _snap_boundaries(data, x, y, x_min, x_max, y_min, y_max)
+    x_pixels, y_pixels = _set_pixels(data, x_pixels, y_pixels, x_min, x_max, y_min, y_max)
+    _check_boundaries(x_pixels, y_pixels, x_min, x_max, y_min, y_max)
 
-    # set # of pixels to maintain an aspect ratio that is the same as the underlying bounds of the data.
-    if x_pixels is None and y_pixels is None:
-        x_pixels = 512
-    if x_pixels is None:
-        x_pixels = int(np.rint(y_pixels * ((x_max - x_min) / (y_max - y_min))))
-    if y_pixels is None:
-        y_pixels = int(np.rint(x_pixels * ((y_max - y_min) / (x_max - x_min))))
-
-    if kernel is None:
-        kernel = data.kernel
-
-    if x not in data.columns:
-        raise KeyError(f"x-directional column '{x}' does not exist in the provided dataset.")
-    if y not in data.columns:
-        raise KeyError(f"y-directional column '{y}' does not exist in the provided dataset.")
-    if target not in data.columns:
-        raise KeyError(f"Target column '{target}' does not exist in provided dataset.")
-    if data.mcol is None:
-        raise KeyError("Mass column does not exist in the provided dataset, please create it with "
-                       "sdf.create_mass_column().")
-    if data.rhocol is None:
-        raise KeyError("Density column does not exist in the provided dataset, please create it with"
-                       "sdf.derive_density().")
-    if data.hcol is None:
-        raise KeyError("Smoothing length column does not exist in the provided dataset.")
-
-    if data.get_dim() != 3:
-        raise ValueError(f"Dataset is not 3-dimensional.")
-    if x_max - x_min <= 0:
-        raise ValueError("`x_max` must be greater than `x_min`!")
-    if y_max - y_min <= 0:
-        raise ValueError("`y_max` must be greater than `y_min`!")
-    if x_pixels <= 0:
-        raise ValueError("`x_pixels` must be greater than zero!")
-    if y_pixels <= 0:
-        raise ValueError("`y_pixels` must be greater than zero!")
-
-    x_data = data[x].to_numpy()
-    y_data = data[y].to_numpy()
-    if rotation is not None:
-        if not isinstance(rotation, Rotation):
-            rotation = R.from_euler('zyx', rotation, degrees=True)
-
-        vectors = data[[data.xcol, data.ycol, data.zcol]].to_numpy()
-        if origin is None:
-            origin = (vectors[:, 0].min() + vectors[:, 0].max()) / 2
-
-        vectors = vectors - origin
-        vectors = rotation.apply(vectors)
-        vectors = vectors + origin
-
-        x_data = vectors[:, 0] if x == data.xcol else \
-                 vectors[:, 1] if x == data.ycol else \
-                 vectors[:, 2] if x == data.zcol else x_data
-        y_data = vectors[:, 0] if y == data.xcol else \
-                 vectors[:, 1] if y == data.ycol else \
-                 vectors[:, 2] if y == data.zcol else y_data
+    x_data, y_data, _ = _rotate_data(data, x, y, data.zcol, rotation, origin)
+    kernel = _default_kernel(data, kernel)
+    _check_dimension(data, 3)
 
     return _fast_3d(data[target].to_numpy(), x_data, y_data, data['m'].to_numpy(),
                     data['rho'].to_numpy(), data['h'].to_numpy(), kernel.get_column_kernel(integral_samples),
                     kernel.get_radius(), integral_samples, x_pixels, y_pixels, x_min, x_max, y_min, y_max)
-
-
-# Underlying numba-compiled code for 3D column interpolation.
-@njit(parallel=True, fastmath=True)
-def _fast_3d(target, x_data, y_data, mass_data, rho_data, h_data, integrated_kernel, kernel_rad, int_samples, x_pixels,
-             y_pixels, x_min, x_max, y_min, y_max):
-    image = np.zeros((y_pixels, x_pixels))
-    pixwidthx = (x_max - x_min) / x_pixels
-    pixwidthy = (y_max - y_min) / y_pixels
-
-    term = target * mass_data / (rho_data * h_data ** 2)
-
-    # determine maximum and minimum pixels that each particle contributes to
-    ipixmin = np.rint((x_data - kernel_rad * h_data - x_min) / pixwidthx).clip(a_min=0, a_max=x_pixels)
-    jpixmin = np.rint((y_data - kernel_rad * h_data - y_min) / pixwidthy).clip(a_min=0, a_max=y_pixels)
-    ipixmax = np.rint((x_data + kernel_rad * h_data - x_min) / pixwidthx).clip(a_min=0, a_max=x_pixels)
-    jpixmax = np.rint((y_data + kernel_rad * h_data - y_min) / pixwidthy).clip(a_min=0, a_max=y_pixels)
-
-    # iterate through the indexes of non-filtered particles
-    for i in prange(len(term)):
-        # precalculate differences in the x-direction (optimization)
-        dx2i = ((x_min + (np.arange(int(ipixmin[i]), int(ipixmax[i])) + 0.5) * pixwidthx - x_data[i]) ** 2) \
-               * (1 / (h_data[i] ** 2))
-
-        # determine differences in the y-direction
-        ypix = y_min + (np.arange(int(jpixmin[i]), int(jpixmax[i])) + 0.5) * pixwidthy
-        dy = ypix - y_data[i]
-        dy2 = dy * dy * (1 / (h_data[i] ** 2))
-
-        # calculate contributions at pixels i, j due to particle at x, y
-        q2 = dx2i + dy2.reshape(len(dy2), 1)
-        wab = np.interp(np.sqrt(q2), np.linspace(0, kernel_rad, int_samples), integrated_kernel)
-
-        # add contributions to image
-        image[int(jpixmin[i]):int(jpixmax[i]), int(ipixmin[i]):int(ipixmax[i])] += (wab * term[i])
-
-    return image
 
 
 def interpolate_3d_cross(data: 'SarracenDataFrame',
@@ -607,94 +438,175 @@ def interpolate_3d_cross(data: 'SarracenDataFrame',
         exist in `data`.
     """
     # x & y columns default to the variables determined by the SarracenDataFrame.
-    if x is None:
-        x = data.xcol
-    if y is None:
-        y = data.ycol
+    x, y = _default_xy(data, x, y)
+    _verify_columns(data, target, x, y)
+
     if z is None:
         z = data.zcol
-
-    # boundaries of the plot default to the maximum & minimum values of the data.
-    if x_min is None:
-        x_min = _snap(data.loc[:, x].min())
-    if y_min is None:
-        y_min = _snap(data.loc[:, y].min())
-    if x_max is None:
-        x_max = _snap(data.loc[:, x].max())
-    if y_max is None:
-        y_max = _snap(data.loc[:, y].max())
+    if z not in data.columns:
+        raise KeyError(f"z-directional column '{z}' does not exist in the provided dataset.")
 
     # set default slice to be through the data's average z-value.
     if z_slice is None:
         z_slice = _snap(data.loc[:, z].mean())
 
-    if kernel is None:
-        kernel = data.kernel
+    # boundaries of the plot default to the maximum & minimum values of the data.
+    x_min, x_max, y_min, y_max = _snap_boundaries(data, x, y, x_min, x_max, y_min, y_max)
+    x_pixels, y_pixels = _set_pixels(data, x_pixels, y_pixels, x_min, x_max, y_min, y_max)
+    _check_boundaries(x_pixels, y_pixels, x_min, x_max, y_min, y_max)
 
-    # set # of pixels to maintain an aspect ratio that is the same as the underlying bounds of the data.
-    if x_pixels is None and y_pixels is None:
-        x_pixels = 512
-    if x_pixels is None:
-        x_pixels = int(np.rint(y_pixels * ((x_max - x_min) / (y_max - y_min))))
-    if y_pixels is None:
-        y_pixels = int(np.rint(x_pixels * ((y_max - y_min) / (x_max - x_min))))
+    kernel = _default_kernel(data, kernel)
 
-    if x not in data.columns:
-        raise KeyError(f"x-directional column '{x}' does not exist in the provided dataset.")
-    if y not in data.columns:
-        raise KeyError(f"x-directional column '{y}' does not exist in the provided dataset.")
-    if z not in data.columns:
-        raise KeyError(f"z-directional column '{z}' does not exist in the provided dataset.")
-    if target not in data.columns:
-        raise KeyError(f"Target column '{target}' does not exist in provided dataset.")
-    if data.mcol is None:
-        raise KeyError("Mass column does not exist in the provided dataset, please create it with "
-                       "sdf.create_mass_column().")
-    if data.rhocol is None:
-        raise KeyError("Density column does not exist in the provided dataset, please create it with"
-                       "sdf.derive_density().")
-    if data.hcol is None:
-        raise KeyError("Smoothing length column does not exist in the provided dataset.")
+    _check_dimension(data, 3)
 
-    if data.get_dim() != 3:
-        raise ValueError(f"Dataset is not 3-dimensional.")
-    if x_max - x_min <= 0:
-        raise ValueError("`x_max` must be greater than `x_min`!")
-    if y_max - y_min <= 0:
-        raise ValueError("`y_max` must be greater than `y_min`!")
-    if x_pixels <= 0:
-        raise ValueError("`x_pixels` must be greater than zero!")
-    if y_pixels <= 0:
-        raise ValueError("`y_pixels` must be greater than zero!")
-
-    x_data = data[x].to_numpy()
-    y_data = data[y].to_numpy()
-    z_data = data[z].to_numpy()
-    if rotation is not None:
-        if not isinstance(rotation, Rotation):
-            rotation = R.from_euler('zyx', rotation, degrees=True)
-
-        vectors = data[[data.xcol, data.ycol, data.zcol]].to_numpy()
-        if origin is None:
-            origin = (vectors[:, 0].min() + vectors[:, 0].max()) / 2
-
-        vectors = vectors - origin
-        vectors = rotation.apply(vectors)
-        vectors = vectors + origin
-
-        x_data = vectors[:, 0] if x == data.xcol else \
-                 vectors[:, 1] if x == data.ycol else \
-                 vectors[:, 2] if x == data.zcol else x_data
-        y_data = vectors[:, 0] if y == data.xcol else \
-                 vectors[:, 1] if y == data.ycol else \
-                 vectors[:, 2] if y == data.zcol else y_data
-        z_data = vectors[:, 0] if z == data.xcol else \
-                 vectors[:, 1] if z == data.ycol else \
-                 vectors[:, 2] if z == data.zcol else z_data
+    x_data, y_data, z_data = _rotate_data(data, x, y, z, rotation, origin)
 
     return _fast_3d_cross(data[target].to_numpy(), z_slice, x_data, y_data, z_data,
                           data['m'].to_numpy(), data['rho'].to_numpy(), data['h'].to_numpy(), kernel.w,
                           kernel.get_radius(), x_pixels, y_pixels, x_min, x_max, y_min, y_max)
+
+
+# Underlying numba-compiled code for 2D interpolation
+@njit(parallel=True, fastmath=True)
+def _fast_2d(target, x_data, y_data, mass_data, rho_data, h_data, weight_function, kernel_radius, x_pixels, y_pixels,
+             x_min, x_max, y_min, y_max):
+    image = np.zeros((y_pixels, x_pixels))
+    pixwidthx = (x_max - x_min) / x_pixels
+    pixwidthy = (y_max - y_min) / y_pixels
+
+    term = (target * mass_data / (rho_data * h_data ** 2))
+
+    # determine maximum and minimum pixels that each particle contributes to
+    ipixmin = np.rint((x_data - kernel_radius * h_data - x_min) / pixwidthx) \
+        .clip(a_min=0, a_max=x_pixels)
+    jpixmin = np.rint((y_data - kernel_radius * h_data - y_min) / pixwidthy) \
+        .clip(a_min=0, a_max=y_pixels)
+    ipixmax = np.rint((x_data + kernel_radius * h_data - x_min) / pixwidthx) \
+        .clip(a_min=0, a_max=x_pixels)
+    jpixmax = np.rint((y_data + kernel_radius * h_data - y_min) / pixwidthy) \
+        .clip(a_min=0, a_max=y_pixels)
+
+    # iterate through the indexes of non-filtered particles
+    for i in prange(len(term)):
+        # precalculate differences in the x-direction (optimization)
+        dx2i = ((x_min + (np.arange(int(ipixmin[i]), int(ipixmax[i])) + 0.5) * pixwidthx - x_data[i]) ** 2) \
+               * (1 / (h_data[i] ** 2))
+
+        # determine differences in the y-direction
+        ypix = y_min + (np.arange(int(jpixmin[i]), int(jpixmax[i])) + 0.5) * pixwidthy
+        dy = ypix - y_data[i]
+        dy2 = dy * dy * (1 / (h_data[i] ** 2))
+
+        # calculate contributions at pixels i, j due to particle at x, y
+        q2 = dx2i + dy2.reshape(len(dy2), 1)
+        wab = weight_function(np.sqrt(q2), 2)
+
+        # add contributions to image
+        image[int(jpixmin[i]):int(jpixmax[i]), int(ipixmin[i]):int(ipixmax[i])] += (wab * term[i])
+
+    return image
+
+
+# Underlying numba-compiled code for 2D->1D cross-sections
+@njit(parallel=True, fastmath=True)
+def _fast_2d_cross(target, x_data, y_data, mass_data, rho_data, h_data, weight_function, kernel_radius, pixels, x1, x2,
+                   y1, y2):
+    # determine the slope of the cross-section line
+    gradient = 0
+    if not x2 - x1 == 0:
+        gradient = (y2 - y1) / (x2 - x1)
+    yint = y2 - gradient * x2
+
+    # determine the fraction of the line that one pixel represents
+    xlength = np.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
+    pixwidth = xlength / pixels
+    xpixwidth = (x2 - x1) / pixels
+
+    term = target * mass_data / (rho_data * h_data ** 2)
+
+    # the intersections between the line and a particle's 'smoothing circle' are
+    # found by solving a quadratic equation with the below values of a, b, and c.
+    # if the determinant is negative, the particle does not contribute to the
+    # cross-section, and can be removed.
+    aa = 1 + gradient ** 2
+    bb = 2 * gradient * (yint - y_data) - 2 * x_data
+    cc = x_data ** 2 + y_data ** 2 - 2 * yint * y_data + yint ** 2 - (kernel_radius * h_data) ** 2
+    det = bb ** 2 - 4 * aa * cc
+
+    # create a filter for particles that do not contribute to the cross-section
+    filter_det = det >= 0
+    det = np.sqrt(det)
+    cc = None
+
+    output = np.zeros(pixels)
+
+    # the starting and ending x coordinates of the lines intersections with a particle's smoothing circle
+    xstart = ((-bb[filter_det] - det[filter_det]) / (2 * aa)).clip(a_min=x1, a_max=x2)
+    xend = ((-bb[filter_det] + det[filter_det]) / (2 * aa)).clip(a_min=x1, a_max=x2)
+    bb, det = None, None
+
+    # the start and end distances which lie within a particle's smoothing circle.
+    rstart = np.sqrt((xstart - x1) ** 2 + ((gradient * xstart + yint) - y1) ** 2)
+    rend = np.sqrt((xend - x1) ** 2 + (((gradient * xend + yint) - y1) ** 2))
+    xstart, xend = None, None
+
+    # the maximum and minimum pixels that each particle contributes to.
+    ipixmin = np.rint(rstart / pixwidth).clip(a_min=0, a_max=pixels)
+    ipixmax = np.rint(rend / pixwidth).clip(a_min=0, a_max=pixels)
+    rstart, rend = None, None
+
+    # iterate through the indices of all non-filtered particles
+    for i in prange(len(x_data[filter_det])):
+        # determine contributions to all affected pixels for this particle
+        xpix = x1 + (np.arange(int(ipixmin[i]), int(ipixmax[i])) + 0.5) * xpixwidth
+        ypix = gradient * xpix + yint
+        dy = ypix - y_data[filter_det][i]
+        dx = xpix - x_data[filter_det][i]
+
+        q2 = (dx * dx + dy * dy) * (1 / (h_data[filter_det][i] * h_data[filter_det][i]))
+        wab = weight_function(np.sqrt(q2), 2)
+
+        # add contributions to output total, transformed by minimum/maximum pixels
+        output[int(ipixmin[i]):int(ipixmax[i])] += (wab * term[filter_det][i])
+
+    return output
+
+
+# Underlying numba-compiled code for 3D column interpolation.
+@njit(parallel=True, fastmath=True)
+def _fast_3d(target, x_data, y_data, mass_data, rho_data, h_data, integrated_kernel, kernel_rad, int_samples, x_pixels,
+             y_pixels, x_min, x_max, y_min, y_max):
+    image = np.zeros((y_pixels, x_pixels))
+    pixwidthx = (x_max - x_min) / x_pixels
+    pixwidthy = (y_max - y_min) / y_pixels
+
+    term = target * mass_data / (rho_data * h_data ** 2)
+
+    # determine maximum and minimum pixels that each particle contributes to
+    ipixmin = np.rint((x_data - kernel_rad * h_data - x_min) / pixwidthx).clip(a_min=0, a_max=x_pixels)
+    jpixmin = np.rint((y_data - kernel_rad * h_data - y_min) / pixwidthy).clip(a_min=0, a_max=y_pixels)
+    ipixmax = np.rint((x_data + kernel_rad * h_data - x_min) / pixwidthx).clip(a_min=0, a_max=x_pixels)
+    jpixmax = np.rint((y_data + kernel_rad * h_data - y_min) / pixwidthy).clip(a_min=0, a_max=y_pixels)
+
+    # iterate through the indexes of non-filtered particles
+    for i in prange(len(term)):
+        # precalculate differences in the x-direction (optimization)
+        dx2i = ((x_min + (np.arange(int(ipixmin[i]), int(ipixmax[i])) + 0.5) * pixwidthx - x_data[i]) ** 2) \
+               * (1 / (h_data[i] ** 2))
+
+        # determine differences in the y-direction
+        ypix = y_min + (np.arange(int(jpixmin[i]), int(jpixmax[i])) + 0.5) * pixwidthy
+        dy = ypix - y_data[i]
+        dy2 = dy * dy * (1 / (h_data[i] ** 2))
+
+        # calculate contributions at pixels i, j due to particle at x, y
+        q2 = dx2i + dy2.reshape(len(dy2), 1)
+        wab = np.interp(np.sqrt(q2), np.linspace(0, kernel_rad, int_samples), integrated_kernel)
+
+        # add contributions to image
+        image[int(jpixmin[i]):int(jpixmax[i]), int(ipixmin[i]):int(ipixmax[i])] += (wab * term[i])
+
+    return image
 
 
 # Underlying numba-compiled code for 3D->2D cross-sections

--- a/sarracen/kernels/base_kernel.py
+++ b/sarracen/kernels/base_kernel.py
@@ -62,6 +62,20 @@ class BaseKernel:
         return c_kernel
 
     def get_column_kernel_func(self, samples) -> CPUDispatcher:
+        """ Generate a numba-accelerated column kernel function.
+
+        Creates a numba-accelerated function for column kernel weights. This function
+        can be utilized similarly to kernel.w.
+
+        Parameters
+        ----------
+        samples: int
+            Number of sample points to calculate when approximating the kernel.
+
+        Returns
+        -------
+        A numba-accelerated weight function.
+        """
         if self._ckernel_func_cache is not None and samples == 1000:
             return self._ckernel_func_cache
         column_kernel = self.get_column_kernel(samples)

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -42,7 +42,20 @@ def _snap(value: float):
 
 
 def _default_axes(data, x, y):
-    # x & y columns default to the variables determined by the SarracenDataFrame.
+    """Utility function to determine the x & y columns to use for rendering.
+
+    Parameters
+    ----------
+    data: SarracenDataFrame
+        The particle dataset to render.
+    x, y: str
+        The x and y directional column labels passed to the render function.
+
+    Returns
+    -------
+    x, y: str
+        The directional column labels to use for rendering. Defaults to the x-column detected in `data`
+    """
     if x is None:
         x = data.xcol
     if y is None:
@@ -52,7 +65,23 @@ def _default_axes(data, x, y):
 
 
 def _default_bounds(data, x, y, x_min, x_max, y_min, y_max):
-    # boundaries of the plot default to the maximum & minimum values of the data.
+    """Utility function to determine the 2-dimensional boundaries to use in 2D rendering.
+
+    Parameters
+    ----------
+    data: SarracenDataFrame
+        The particle dataset to render.
+    x, y: str
+        The directional column labels that will be used for rendering.
+    x_min, x_max, y_min, y_max: float
+        The minimum and maximum values passed to the render function, in particle data space.
+
+    Returns
+    -------
+    x_min, x_max, y_min, y_max: float
+        The minimum and maximum values to use for rendering, in particle data space. Defaults
+        to the maximum and minimum values of `x` and `y`, snapped to the nearest integer.
+    """
     if x_min is None:
         x_min = _snap(data.loc[:, x].min())
     if y_min is None:
@@ -94,40 +123,31 @@ def render_2d(data: 'SarracenDataFrame',
         Particle data, in a SarracenDataFrame.
     target: str
         Column label of the target smoothing data.
-    x: str, optional
-        Column label of the x-directional axis. Defaults to the x-column detected in `data`.
-    y: str, optional
+    x, y: str, optional
         Column label of the y-directional axis. Defaults to the y-column detected in `data`.
     kernel: BaseKernel, optional
         Kernel to use for smoothing the target data. Defaults to the kernel specified in `data`.
-    x_pixels: int, optional
-        Number of pixels in the output image in the x-direction. If both x_pixels and y_pixels are
-        None, this defaults to 256. Otherwise, this value defaults to a multiple of y_pixels which
-        preserves the aspect ratio of the data.
-    y_pixels: int, optional
-        Number of pixels in the output image in the y-direction. If both x_pixels and y_pixels are
-        None, this defaults to 256. Otherwise, this value defaults to a multiple of x_pixels which
-        preserves the aspect ratio of the data.
-    x_min: float, optional
-        Minimum bound in the x-direction (in particle data space). Defaults to the lower bound
-        of x detected in `data` snapped to the nearest integer.
-    x_max: float, optional
-        Maximum bound in the x-direction (in particle data space). Defaults to the upper bound
-        of x detected in `data` snapped to the nearest integer.
-    y_min: float, optional
-        Minimum bound in the y-direction (in particle data space). Defaults to the lower bound
-        of y detected in `data` snapped to the nearest integer.
-    y_max: float, optional
-        Maximum bound in the y-direction (in particle data space). Defaults to the upper bound
-        of y detected in `data` snapped to the nearest integer.
+    x_pixels, y_pixels: int, optional
+        Number of pixels in the output image in the x & y directions. Default values are chosen to keep
+        a consistent aspect ratio.
+    x_min, x_max, y_min, y_max: float, optional
+        The minimum and maximum values to use in interpolation, in particle data space. Defaults
+        to the minimum and maximum values of `x` and `y`.
     cmap: str or Colormap, optional
         The color map to use when plotting this data.
+    cbar: bool, optional
+        True if a colorbar should be drawn.
+    cbar_kws: dict, optional
+        Keyword arguments to pass to matplotlib.figure.Figure.colorbar()
+    cbar_ax: Axes
+        Axes to draw the colorbar in, if not provided then space will be taken from the main Axes.
+    ax: Axes
+        The main axes in which to draw the rendered image.
+    kwargs: other keyword arguments
+        Keyword arguments to pass to matplotlib.axes.Axes.imshow().
 
     Returns
     -------
-    Figure
-        The resulting matplotlib figure, containing the 2d render and
-        a color bar indicating the magnitude of the target variable.
     Axes
         The resulting matplotlib axes, which contain the 2d rendered image.
 
@@ -185,34 +205,24 @@ def render_2d_cross(data: 'SarracenDataFrame',
         Particle data, in a SarracenDataFrame.
     target: str
         Column label of the target smoothing data.
-    x: str, optional
-        Column label of the x-directional axis. Defaults to the x-column detected in `data`.
-    y: str, optional
-        Column label of the y-directional axis. Defaults to the y-column detected in `data`.
-    kernel: BaseKernel
+    x, y: str
+        Column labels of the directional axes. Defaults to the x & y columns detected in `data`.
+    kernel: BaseKernel, optional
         Kernel to use for smoothing the target data. Defaults to the kernel specified in `data`.
     pixels: int, optional
         Number of points in the resulting line plot in the x-direction.
-    x1: float, optional
-        Starting x-coordinate of the line (in particle data space). Defaults to the lower bound
-        of x detected in `data` snapped to the nearest integer.
-    x2: float, optional
-        Ending x-coordinate of the line (in particle data space). Defaults to the upper bound
-        of x detected in `data` snapped to the nearest integer.
-    y1: float, optional
-        Starting y-coordinate of the line (in particle data space). Defaults to the lower bound
-        of y detected in `data` snapped to the nearest integer.
-    y2: float, optional
-        Ending y-coordinate of the line (in particle data space). Defaults to the upper bound
-        of y detected in `data` snapped to the nearest integer.
+    x1, x2, y1, y2: float, optional
+        Starting and ending coordinates of the cross-section line (in particle data space). Defaults to
+        the minimum and maximum values of `x` and `y`.
+    ax: Axes
+        The main axes in which to draw the rendered image.
+    kwargs: other keyword arguments
+        Keyword arguments to pass to seaborn.lineplot().
 
     Returns
     -------
-    Figure
-        The resulting matplotlib figure, containing the seaborn-generated
-        line plot.
     Axes
-        The resulting matplotlib axes, which contain the line plot.
+        The resulting matplotlib axes, which contains the 1d cross-sectional plot.
 
     Raises
     -------
@@ -272,10 +282,8 @@ def render_3d(data: 'SarracenDataFrame',
         Particle data, in a SarracenDataFrame.
     target: str
         Column label of the target smoothing data.
-    x: str, optional
-        Column label of the x-directional axis to interpolate over. Defaults to the x-column detected in `data`.
-    y: str, optional
-        Column label of the y-directional axis to interpolate over. Defaults to the y-column detected in `data`.
+    x, y: str
+        Column labels of the directional axes. Defaults to the x & y columns detected in `data`.
     kernel: BaseKernel, optional
         Kernel to use for smoothing the target data. Defaults to the kernel specified in `data`.
     integral_samples: int, optional
@@ -286,36 +294,29 @@ def render_3d(data: 'SarracenDataFrame',
     origin: array_like, optional
         Point of rotation of the data, in [x, y, z] form. Defaults to the centre
         point of the bounds of the data.
-    x_pixels: int, optional
-        Number of pixels in the output image in the x-direction. If both x_pixels and y_pixels are
-        None, this defaults to 256. Otherwise, this value defaults to a multiple of y_pixels which
-        preserves the aspect ratio of the data.
-    y_pixels: int, optional
-        Number of pixels in the output image in the y-direction. If both x_pixels and y_pixels are
-        None, this defaults to 256. Otherwise, this value defaults to a multiple of x_pixels which
-        preserves the aspect ratio of the data.
-    x_min: float, optional
-        Minimum bound in the x-direction (in particle data space). Defaults to the lower bound
-        of x detected in `data` snapped to the nearest integer.
-    x_max: float, optional
-        Maximum bound in the x-direction (in particle data space). Defaults to the upper bound
-        of x detected in `data` snapped to the nearest integer.
-    y_min: float, optional
-        Minimum bound in the y-direction (in particle data space). Defaults to the lower bound
-        of y detected in `data` snapped to the nearest integer.
-    y_max: float, optional
-        Maximum bound in the y-direction (in particle data space). Defaults to the upper bound
-        of y detected in `data` snapped to the nearest integer.
+    x_pixels, y_pixels: int, optional
+        Number of pixels in the output image in the x & y directions. Default values are chosen to keep
+        a consistent aspect ratio.
+    x_min, x_max, y_min, y_max: float, optional
+        The minimum and maximum values to render over, in particle data space. Defaults
+        to the minimum and maximum values of `x` and `y`.
     cmap: str or Colormap, optional
         The color map to use when plotting this data.
+    cbar: bool, optional
+        True if a colorbar should be drawn.
+    cbar_kws: dict, optional
+        Keyword arguments to pass to matplotlib.figure.Figure.colorbar()
+    cbar_ax: Axes
+        Axes to draw the colorbar in, if not provided then space will be taken from the main Axes.
+    ax: Axes
+        The main axes in which to draw the rendered image.
+    kwargs: other keyword arguments
+        Keyword arguments to pass to matplotlib.axes.Axes.imshow().
 
     Returns
     -------
-    Figure
-        The resulting matplotlib figure, containing the 2d render and
-        a color bar indicating the magnitude of the target variable.
     Axes
-        The resulting matplotlib axes, which contain the 2d rendered image.
+        The resulting matplotlib axes, which contains the 2d rendered image.
 
     Raises
     -------
@@ -324,11 +325,11 @@ def render_3d(data: 'SarracenDataFrame',
         if the specified `x` and `y` minimum and maximums result in an invalid region, or
         if the provided data is not 3-dimensional.
     KeyError
-        If `target`, `x`, `y`, `z`, mass, density, or smoothing length columns do not
+        If `target`, `x`, `y`, mass, density, or smoothing length columns do not
         exist in `data`.
     """
     image = interpolate_3d(data, target, x, y, kernel, integral_samples, rotation, origin, x_pixels, y_pixels, x_min,
-                         x_max, y_min, y_max)
+                           x_max, y_min, y_max)
 
     if ax is None:
         ax = plt.gca()
@@ -386,60 +387,50 @@ def render_3d_cross(data: 'SarracenDataFrame',
     Parameters
     ----------
     data : SarracenDataFrame
-        Particle data, in a SarracenDataFrame.
+        The particle data to render.
     target: str
-        Column label of the target smoothing data.
-    z_slice: float, optional
-        Z-axis value to take the cross-section at. Defaults to the average z position in `data`.
-    x: str, optional
-        Column label of the x-directional axis. Defaults to the x-column detected in `data`.
-    y: str, optional
-        Column label of the y-directional axis. Defaults to the y-column detected in `data`.
-    z: str
-        Column label of the z-directional axis. Defaults to the z-column detected in `data`.
-    kernel: BaseKernel, optional
-        Kernel to use for smoothing the target data. Defaults to the kernel specified in `data`.
+        The column label of the target smoothing data.
+    z_slice: float
+        The z-axis value to take the cross-section at. Defaults to the midpoint of the z-directional data.
+    x, y, z: str
+        The column labels of the directional data to render. Defaults to the x, y, and z columns
+        detected in `data`.
+    kernel: BaseKernel
+        The kernel to use for smoothing the target data. Defaults to the kernel specified in `data`.
     rotation: array_like or Rotation, optional
-        The rotation to apply to the data before interpolation. If defined as an array, the
+        The rotation to apply to the data before rendering. If defined as an array, the
         order of rotations is [z, y, x] in degrees.
     origin: array_like, optional
         Point of rotation of the data, in [x, y, z] form. Defaults to the centre
         point of the bounds of the data.
-    x_pixels: int, optional
-        Number of pixels in the output image in the x-direction. If both x_pixels and y_pixels are
-        None, this defaults to 256. Otherwise, this value defaults to a multiple of y_pixels which
-        preserves the aspect ratio of the data.
-    y_pixels: int, optional
-        Number of pixels in the output image in the y-direction. If both x_pixels and y_pixels are
-        None, this defaults to 256. Otherwise, this value defaults to a multiple of x_pixels which
-        preserves the aspect ratio of the data.
-    x_min: float, optional
-        Minimum bound in the x-direction (in particle data space). Defaults to the lower bound
-        of x detected in `data` snapped to the nearest integer.
-    x_max: float, optional
-        Maximum bound in the x-direction (in particle data space). Defaults to the upper bound
-        of x detected in `data` snapped to the nearest integer.
-    y_min: float, optional
-        Minimum bound in the y-direction (in particle data space). Defaults to the lower bound
-        of y detected in `data` snapped to the nearest integer.
-    y_max: float, optional
-        Maximum bound in the y-direction (in particle data space). Defaults to the upper bound
-        of y detected in `data` snapped to the nearest integer.
+    x_pixels, y_pixels: int, optional
+        Number of pixels in the output image in the x & y directions. Default values are chosen to keep
+        a consistent aspect ratio.
+    x_min, x_max, y_min, y_max: float, optional
+        The minimum and maximum values to render over, in particle data space. Defaults
+        to the minimum and maximum values of `x` and `y`.
     cmap: str or Colormap, optional
         The color map to use when plotting this data.
+    cbar: bool, optional
+        True if a colorbar should be drawn.
+    cbar_kws: dict, optional
+        Keyword arguments to pass to matplotlib.figure.Figure.colorbar()
+    cbar_ax: Axes
+        Axes to draw the colorbar in, if not provided then space will be taken from the main Axes.
+    ax: Axes
+        The main axes in which to draw the rendered image.
+    kwargs: other keyword arguments
+        Keyword arguments to pass to matplotlib.axes.Axes.imshow().
 
     Returns
     -------
-    Figure
-        The resulting matplotlib figure, containing the 3d-cross section and
-        a color bar indicating the magnitude of the target variable.
     Axes
-        The resulting matplotlib axes, which contains the 3d-cross section image.
+        The resulting matplotlib axes object, containing the 3d cross-section image.
 
     Raises
     -------
     ValueError
-        If `pixwidthx`, `pixwidthy`, `pixcountx`, or `pixcounty` are less than or equal to zero, or
+        If `x_pixels` or `y_pixels` are less than or equal to zero, or
         if the specified `x` and `y` minimum and maximums result in an invalid region, or
         if the provided data is not 3-dimensional.
     KeyError
@@ -447,7 +438,7 @@ def render_3d_cross(data: 'SarracenDataFrame',
         exist in `data`.
     """
     image = interpolate_3d_cross(data, target, z_slice, x, y, z, kernel, rotation, origin, x_pixels, y_pixels, x_min,
-                               x_max, y_min, y_max)
+                                 x_max, y_min, y_max)
 
     if ax is None:
         ax = plt.gca()

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -158,9 +158,13 @@ class SarracenDataFrame(DataFrame):
                   y_min: float = None,
                   y_max: float = None,
                   cmap: Union[str, Colormap] = 'RdBu',
-                  ax: Axes = None) -> Axes:
+                  cbar: bool = True,
+                  cbar_kws: dict = {},
+                  cbar_ax: Axes = None,
+                  ax: Axes = None,
+                  **kwargs) -> Axes:
 
-        return render_2d(self, target, x, y, kernel, x_pixels, y_pixels, x_min, x_max, y_min, y_max, cmap, ax)
+        return render_2d(self, target, x, y, kernel, x_pixels, y_pixels, x_min, x_max, y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, **kwargs)
 
     @_copy_doc(render_2d_cross)
     def render_2d_cross(self,
@@ -173,9 +177,10 @@ class SarracenDataFrame(DataFrame):
                         y1: float = None,
                         x2: float = None,
                         y2: float = None,
-                        ax: Axes = None) -> Axes:
+                        ax: Axes = None,
+                        **kwargs) -> Axes:
 
-        return render_2d_cross(self, target, x, y, kernel, pixels, x1, x2, y1, y2, ax)
+        return render_2d_cross(self, target, x, y, kernel, pixels, x1, x2, y1, y2, ax, **kwargs)
 
     @_copy_doc(render_3d)
     def render_3d(self,
@@ -193,10 +198,14 @@ class SarracenDataFrame(DataFrame):
                   y_min: float = None,
                   y_max: float = None,
                   cmap: Union[str, Colormap] = 'RdBu',
-                  ax: Axes = None) -> Axes:
+                  cbar: bool = True,
+                  cbar_kws: dict = {},
+                  cbar_ax: Axes = None,
+                  ax: Axes = None,
+                  **kwargs) -> Axes:
 
         return render_3d(self, target, x, y, kernel, int_samples, rotation, origin, x_pixels, y_pixels, x_min, x_max, y_min, y_max,
-                         cmap, ax)
+                         cmap, cbar, cbar_kws, cbar_ax, ax, **kwargs)
 
     @_copy_doc(render_3d_cross)
     def render_3d_cross(self,
@@ -215,10 +224,14 @@ class SarracenDataFrame(DataFrame):
                         y_min: float = None,
                         y_max: float = None,
                         cmap: Union[str, Colormap] = 'RdBu',
-                        ax: Axes = None) -> Axes:
+                        cbar: bool = True,
+                        cbar_kws: dict = {},
+                        cbar_ax: Axes = None,
+                        ax: Axes = None,
+                        **kwargs) -> Axes:
 
         return render_3d_cross(self, target, z_slice, x, y, z, kernel, rotation, origin, x_pixels, y_pixels, x_min,
-                               x_max, y_min, y_max, cmap, ax)
+                               x_max, y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, **kwargs)
 
     @property
     def params(self):

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -1,5 +1,6 @@
 from typing import Union, Callable
 
+from matplotlib.axes import Axes
 from matplotlib.colors import Colormap
 from pandas import DataFrame, Series
 import numpy as np
@@ -156,9 +157,10 @@ class SarracenDataFrame(DataFrame):
                   x_max: float = None,
                   y_min: float = None,
                   y_max: float = None,
-                  colormap: Union[str, Colormap] = 'RdBu') -> ('Figure', 'Axes'):
+                  cmap: Union[str, Colormap] = 'RdBu',
+                  ax: Axes = None) -> Axes:
 
-        return render_2d(self, target, x, y, kernel, x_pixels, y_pixels, x_min, x_max, y_min, y_max, colormap)
+        return render_2d(self, target, x, y, kernel, x_pixels, y_pixels, x_min, x_max, y_min, y_max, cmap, ax)
 
     @_copy_doc(render_2d_cross)
     def render_2d_cross(self,
@@ -170,9 +172,10 @@ class SarracenDataFrame(DataFrame):
                         x1: float = None,
                         y1: float = None,
                         x2: float = None,
-                        y2: float = None) -> ('Figure', 'Axes'):
+                        y2: float = None,
+                        ax: Axes = None) -> Axes:
 
-        return render_2d_cross(self, target, x, y, kernel, pixels, x1, x2, y1, y2)
+        return render_2d_cross(self, target, x, y, kernel, pixels, x1, x2, y1, y2, ax)
 
     @_copy_doc(render_3d)
     def render_3d(self,
@@ -189,10 +192,11 @@ class SarracenDataFrame(DataFrame):
                   x_max: float = None,
                   y_min: float = None,
                   y_max: float = None,
-                  colormap: Union[str, Colormap] = 'RdBu') -> ('Figure', 'Axes'):
+                  cmap: Union[str, Colormap] = 'RdBu',
+                  ax: Axes = None) -> Axes:
 
         return render_3d(self, target, x, y, kernel, int_samples, rotation, origin, x_pixels, y_pixels, x_min, x_max, y_min, y_max,
-                         colormap)
+                         cmap, ax)
 
     @_copy_doc(render_3d_cross)
     def render_3d_cross(self,
@@ -210,10 +214,11 @@ class SarracenDataFrame(DataFrame):
                         x_max: float = None,
                         y_min: float = None,
                         y_max: float = None,
-                        colormap: Union[str, Colormap] = 'RdBu') -> ('Figure', 'Axes'):
+                        cmap: Union[str, Colormap] = 'RdBu',
+                        ax: Axes = None) -> Axes:
 
         return render_3d_cross(self, target, z_slice, x, y, z, kernel, rotation, origin, x_pixels, y_pixels, x_min,
-                               x_max, y_min, y_max, colormap)
+                               x_max, y_min, y_max, cmap, ax)
 
     @property
     def params(self):

--- a/sarracen/tests/test_render.py
+++ b/sarracen/tests/test_render.py
@@ -1,6 +1,7 @@
 """pytest unit tests for render.py functions."""
 import pandas as pd
 import numpy as np
+from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from pytest import approx
@@ -19,15 +20,15 @@ def test_2d_plot():
                        'm': [1, 1]})
     sdf = SarracenDataFrame(df)
 
-    fig, ax = sdf.render_2d('P')
+    fig, ax = plt.subplots()
+    sdf.render_2d('P', ax=ax)
 
-    assert isinstance(fig, Figure)
     assert isinstance(ax, Axes)
 
     assert ax.get_xlabel() == 'x'
     assert ax.get_ylabel() == 'y'
     # the colorbar is contained in a second axes object inside the figure
-    assert fig.axes[1].get_ylabel() == 'P'
+    assert ax.figure.axes[1].get_ylabel() == 'P'
 
     assert ax.get_xlim() == (3, 6)
     assert ax.get_ylim() == (1, 5)
@@ -38,7 +39,7 @@ def test_2d_plot():
     # both particles are in corners
     # therefore closest pixel is => sqrt((3/1024)**2, (2/683)**2)
     # use default kernel to determine the max pressure value
-    assert fig.axes[1].get_ylim() == (0, CubicSplineKernel().w(np.sqrt((3 / 1024) ** 2 + (2 / 683) ** 2), 2))
+    assert ax.figure.axes[1].get_ylim() == (0, CubicSplineKernel().w(np.sqrt((3 / 1024) ** 2 + (2 / 683) ** 2), 2))
 
 
 def test_2d_cross_plot():
@@ -50,9 +51,9 @@ def test_2d_cross_plot():
                        'm': [1, 1]})
     sdf = SarracenDataFrame(df)
 
-    fig, ax = sdf.render_2d_cross('P')
+    fig, ax = plt.subplots()
+    sdf.render_2d_cross('P', ax=ax)
 
-    assert isinstance(fig, Figure)
     assert isinstance(ax, Axes)
 
     assert ax.get_xlabel() == 'cross-section (rx, y)'
@@ -76,22 +77,22 @@ def test_3d_plot():
                        'm': [1, 1]})
     sdf = SarracenDataFrame(df)
 
-    fig, ax = sdf.render_3d('P', int_samples=10000, x_pixels=300)
+    fig, ax = plt.subplots()
+    sdf.render_3d('P', int_samples=10000, x_pixels=300, ax=ax)
 
-    assert isinstance(fig, Figure)
     assert isinstance(ax, Axes)
 
     assert ax.get_xlabel() == 'rx'
     assert ax.get_ylabel() == 'y'
     # the colorbar is contained in a second axes object inside the figure
-    assert fig.axes[1].get_ylabel() == 'column P'
+    assert ax.figure.axes[1].get_ylabel() == 'column P'
 
     assert ax.get_xlim() == (0, 5)
     assert ax.get_ylim() == (0, 4)
     # particle width is 1/60
     # therefore closest pixel has q=sqrt(2*(1/120)^2)
     # F(q) ~= 0.477372919027 (calculated externally)
-    assert fig.axes[1].get_ylim() == (0, approx(0.477372919027))
+    assert ax.figure.axes[1].get_ylim() == (0, approx(0.477372919027))
 
 
 def test_3d_cross_plot():
@@ -106,21 +107,21 @@ def test_3d_cross_plot():
 
     # setting the pixel count to an odd number ensures that the middle particle at (2.5, 2, 2) is at the
     # exact same position as the centre pixel.
-    fig, ax = sdf.render_3d_cross('P', x_pixels=489)
+    fig, ax = plt.subplots()
+    sdf.render_3d_cross('P', x_pixels=489, ax=ax)
 
-    assert isinstance(fig, Figure)
     assert isinstance(ax, Axes)
 
     assert ax.get_xlabel() == 'rx'
     assert ax.get_ylabel() == 'y'
     # the colorbar is contained in a second axes object inside the figure
-    assert fig.axes[1].get_ylabel() == 'P'
+    assert ax.figure.axes[1].get_ylabel() == 'P'
 
     assert ax.get_xlim() == (0, 5)
     assert ax.get_ylim() == (0, 4)
 
     # closest pixel/particle pair comes from the particle at (2.5, 2, 2), with r = 0.
-    assert fig.axes[1].get_ylim() == (0, approx(CubicSplineKernel().w(0, 3)))
+    assert ax.figure.axes[1].get_ylim() == (0, approx(CubicSplineKernel().w(0, 3)))
 
 
 def test_render_passthrough():
@@ -134,28 +135,32 @@ def test_render_passthrough():
                        'm': [1, 1]})
     sdf = SarracenDataFrame(df)
 
-    fig1, ax1 = sdf.render_2d('P')
-    fig2, ax2 = render_2d(sdf, 'P')
+    fig1, ax1 = plt.subplots()
+    fig2, ax2 = plt.subplots()
+    ax1 = sdf.render_2d('P', ax=ax1)
+    ax2 = render_2d(sdf, 'P', ax=ax2)
 
-    assert repr(fig1) == repr(fig2)
     assert repr(ax1) == repr(ax2)
 
-    fig1, ax1 = sdf.render_2d_cross('P')
-    fig2, ax2 = render_2d_cross(sdf, 'P')
+    fig1, ax1 = plt.subplots()
+    fig2, ax2 = plt.subplots()
+    ax1 = sdf.render_2d_cross('P', ax=ax1)
+    ax2 = render_2d_cross(sdf, 'P', ax=ax2)
 
-    assert repr(fig1) == repr(fig2)
     assert repr(ax1) == repr(ax2)
 
-    fig1, ax1 = sdf.render_3d('P')
-    fig2, ax2 = render_3d(sdf, 'P')
+    fig1, ax1 = plt.subplots()
+    fig2, ax2 = plt.subplots()
+    ax1 = sdf.render_3d('P', ax=ax1)
+    ax2 = render_3d(sdf, 'P', ax=ax2)
 
-    assert repr(fig1) == repr(fig2)
     assert repr(ax1) == repr(ax2)
 
-    fig1, ax1 = sdf.render_3d_cross('P')
-    fig2, ax2 = render_3d_cross(sdf, 'P')
+    fig1, ax1 = plt.subplots()
+    fig2, ax2 = plt.subplots()
+    ax1 = sdf.render_3d_cross('P', ax=ax1)
+    ax2 = render_3d_cross(sdf, 'P', ax=ax2)
 
-    assert repr(fig1) == repr(fig2)
     assert repr(ax1) == repr(ax2)
 
 
@@ -167,7 +172,9 @@ def test_snap():
                        'rho': [1, 1],
                        'm': [1, 1]})
     sdf = SarracenDataFrame(df)
-    fig, ax = sdf.render_2d('P')
+
+    fig, ax = plt.subplots()
+    sdf.render_2d('P', ax=ax)
 
     # 0.0001 -> 0.0, 5.2 -> 5.2
     assert ax.get_xlim() == (0.0, 5.2)

--- a/sarracen/tests/test_render.py
+++ b/sarracen/tests/test_render.py
@@ -126,11 +126,12 @@ def test_3d_cross_plot():
 
 def test_render_passthrough():
     # Basic tests that both sdf.render() and render(sdf) return the same plots
+
+    # 2D dataset
     df = pd.DataFrame({'x': [3, 6],
                        'y': [5, 1],
                        'P': [1, 1],
                        'h': [1, 1],
-                       'z': [6, 3],
                        'rho': [1, 1],
                        'm': [1, 1]})
     sdf = SarracenDataFrame(df)
@@ -148,6 +149,16 @@ def test_render_passthrough():
     ax2 = render_2d_cross(sdf, 'P', ax=ax2)
 
     assert repr(ax1) == repr(ax2)
+
+    # 3D dataset
+    df = pd.DataFrame({'x': [3, 6],
+                       'y': [5, 1],
+                       'z': [2, 1],
+                       'P': [1, 1],
+                       'h': [1, 1],
+                       'rho': [1, 1],
+                       'm': [1, 1]})
+    sdf = SarracenDataFrame(df)
 
     fig1, ax1 = plt.subplots()
     fig2, ax2 = plt.subplots()


### PR DESCRIPTION
Adds new arguments to the sarracen render API, which allows passing of custom arguments to underlying matplotlib & seaborn functions. The resulting plots can now be customized to a much deeper degree. As well, the render functions can now be passed a user-defined axes object, allowing for the creation of larger plots and multiplots.

Internally, the codebase for interpolation and rendering has been refactored to share common code. Three of the four interpolation functions now use a single internal numba function, which will simplify further updates.