### PR TITLE
Interpolated plotting of vector quantities

### DIFF
--- a/sarracen/interpolate.py
+++ b/sarracen/interpolate.py
@@ -215,23 +215,17 @@ def _rotate_data(data, x, y, z, rotation, origin):
         if not isinstance(rotation, Rotation):
             rotation = R.from_euler('zyx', rotation, degrees=True)
 
-        vectors = data[[data.xcol, data.ycol, data.zcol]].to_numpy()
+        vectors = data[[x, y, z]].to_numpy()
         if origin is None:
-            origin = (vectors[:, 0].min() + vectors[:, 0].max()) / 2
+            origin = (vectors.min(0) + vectors.max(0)) / 2
 
         vectors = vectors - origin
         vectors = rotation.apply(vectors)
         vectors = vectors + origin
 
-        x_data = vectors[:, 0] if x == data.xcol else \
-            vectors[:, 1] if x == data.ycol else \
-            vectors[:, 2] if x == data.zcol else x_data
-        y_data = vectors[:, 0] if y == data.xcol else \
-            vectors[:, 1] if y == data.ycol else \
-            vectors[:, 2] if y == data.zcol else y_data
-        z_data = vectors[:, 0] if z == data.xcol else \
-            vectors[:, 1] if z == data.ycol else \
-            vectors[:, 2] if z == data.zcol else z_data
+        x_data = vectors[:, 0]
+        y_data = vectors[:, 1]
+        z_data = vectors[:, 2]
 
     return x_data, y_data, z_data
 
@@ -291,6 +285,29 @@ def interpolate_2d(data: 'SarracenDataFrame', target: str, x: str = None, y: str
     return _fast_2d(data[target].to_numpy(), 0, data[x].to_numpy(), data[y].to_numpy(), np.zeros(len(data)),
                     data['m'].to_numpy(), data['rho'].to_numpy(), data['h'].to_numpy(), kernel.w, kernel.get_radius(),
                     x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2)
+
+
+def interpolate_2d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, x: str = None, y: str = None,
+                       kernel: BaseKernel = None, x_pixels: int = None, y_pixels: int = None, x_min: float = None,
+                       x_max: float = None, y_min: float = None, y_max: float = None, backend: str = None):
+    x, y = _default_xy(data, x, y)
+    _verify_columns(data, x, y, target_x)
+    _verify_columns(data, x, y, target_y)
+
+    x_min, x_max, y_min, y_max = _snap_boundaries(data, x, y, x_min, x_max, y_min, y_max)
+    x_pixels, y_pixels = _set_pixels(x_pixels, y_pixels, x_min, x_max, y_min, y_max)
+    _check_boundaries(x_pixels, y_pixels, x_min, x_max, y_min, y_max)
+
+    kernel = kernel if kernel is not None else data.kernel
+    #backend = backend if backend is not None else data.backend
+    _check_dimension(data, 2)
+
+    return (_fast_2d(data[target_x].to_numpy(), 0, data[x].to_numpy(), data[y].to_numpy(), np.zeros(len(data)),
+                     data['m'].to_numpy(), data['rho'].to_numpy(), data['h'].to_numpy(), kernel.w,
+                     kernel.get_radius(), x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2),\
+           _fast_2d(data[target_y].to_numpy(), 0, data[x].to_numpy(), data[y].to_numpy(), np.zeros(len(data)),
+                    data['m'].to_numpy(), data['rho'].to_numpy(), data['h'].to_numpy(), kernel.w,
+                    kernel.get_radius(), x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2))
 
 
 def interpolate_2d_cross(data: 'SarracenDataFrame',
@@ -440,6 +457,38 @@ def interpolate_3d(data: 'SarracenDataFrame',
                     kernel.get_radius(), x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2)
 
 
+def interpolate_3d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, target_z: str, x: str = None,
+                       y: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
+                       rotation: np.ndarray = None, origin: np.ndarray = None, x_pixels: int = None,
+                       y_pixels: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
+                       y_max: float = None, backend: str = None):
+    x, y = _default_xy(data, x, y)
+    _verify_columns(data, x, y, target_x)
+    _verify_columns(data, x, y, target_y)
+    _verify_columns(data, x, y, target_z)
+
+    x_min, x_max, y_min, y_max = _snap_boundaries(data, x, y, x_min, x_max, y_min, y_max)
+    x_pixels, y_pixels = _set_pixels(x_pixels, y_pixels, x_min, x_max, y_min, y_max)
+    _check_boundaries(x_pixels, y_pixels, x_min, x_max, y_min, y_max)
+
+    x_data, y_data, _ = _rotate_data(data, x, y, data.zcol, rotation, origin)
+    if target_z not in data.columns:
+        raise KeyError(f"z-directional target column '{target_z}' does not exist in the provided dataset.")
+    target_x_data, target_y_data, _ = _rotate_data(data, target_x, target_y, target_z, rotation, origin)
+
+    kernel = kernel if kernel is not None else data.kernel
+    #backend = backend if backend is not None else data.backend
+    _check_dimension(data, 3)
+
+    weight_function = kernel.get_column_kernel_func(integral_samples)
+    return (_fast_2d(target_x_data, 0, x_data, y_data, np.zeros(len(data)), data['m'].to_numpy(),
+                    data['rho'].to_numpy(), data['h'].to_numpy(), weight_function,
+                    kernel.get_radius(), x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2),\
+           _fast_2d(target_y_data, 0, x_data, y_data, np.zeros(len(data)), data['m'].to_numpy(),
+                    data['rho'].to_numpy(), data['h'].to_numpy(), weight_function,
+                    kernel.get_radius(), x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2))
+
+
 def interpolate_3d_cross(data: 'SarracenDataFrame',
                          target: str,
                          z_slice: float = None,
@@ -530,6 +579,45 @@ def interpolate_3d_cross(data: 'SarracenDataFrame',
     return _fast_2d(data[target].to_numpy(), z_slice, x_data, y_data, z_data,
                     data['m'].to_numpy(), data['rho'].to_numpy(), data['h'].to_numpy(), kernel.w,
                     kernel.get_radius(), x_pixels, y_pixels, x_min, x_max, y_min, y_max, 3)
+
+
+def interpolate_3d_cross_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, target_z: str,
+                             z_slice: float = None, x: str = None, y: str = None, z: str = None,
+                             kernel: BaseKernel = None, rotation: np.ndarray = None, origin: np.ndarray = None,
+                             x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None,
+                             y_min: float = None, y_max: float = None, backend: str = None):
+    x, y = _default_xy(data, x, y)
+    _verify_columns(data, x, y, target_x)
+    _verify_columns(data, x, y, target_y)
+    _verify_columns(data, x, y, target_z)
+
+    if z is None:
+        z = data.zcol
+    if z not in data.columns:
+        raise KeyError(f"z-directional column '{z}' does not exist in the provided dataset.")
+
+    # set default slice to be through the data's average z-value.
+    if z_slice is None:
+        z_slice = _snap(data.loc[:, z].mean())
+
+    # boundaries of the plot default to the maximum & minimum values of the data.
+    x_min, x_max, y_min, y_max = _snap_boundaries(data, x, y, x_min, x_max, y_min, y_max)
+    x_pixels, y_pixels = _set_pixels(x_pixels, y_pixels, x_min, x_max, y_min, y_max)
+    _check_boundaries(x_pixels, y_pixels, x_min, x_max, y_min, y_max)
+
+    x_data, y_data, z_data = _rotate_data(data, x, y, data.zcol, rotation, origin)
+    target_x_data, target_y_data, _ = _rotate_data(data, target_x, target_y, target_z, rotation, origin)
+
+    kernel = kernel if kernel is not None else data.kernel
+    #backend = backend if backend is not None else data.backend
+    _check_dimension(data, 3)
+
+    return (_fast_2d(target_x_data, z_slice, x_data, y_data, z_data, data['m'].to_numpy(),
+                     data['rho'].to_numpy(), data['h'].to_numpy(), kernel.w, kernel.get_radius(), x_pixels, y_pixels,
+                     x_min, x_max, y_min, y_max, 3),
+            _fast_2d(target_y_data, z_slice, x_data, y_data, z_data, data['m'].to_numpy(),
+                     data['rho'].to_numpy(), data['h'].to_numpy(), kernel.w, kernel.get_radius(), x_pixels, y_pixels,
+                     x_min, x_max, y_min, y_max, 3))
 
 
 # Underlying numba-compiled code for interpolation to a 2D grid. Used in interpolation of 2D data,

--- a/sarracen/interpolate.py
+++ b/sarracen/interpolate.py
@@ -130,7 +130,7 @@ def _verify_columns(data, target, x, y):
     if x not in data.columns:
         raise KeyError(f"x-directional column '{x}' does not exist in the provided dataset.")
     if y not in data.columns:
-        raise KeyError(f"x-directional column '{y}' does not exist in the provided dataset.")
+        raise KeyError(f"y-directional column '{y}' does not exist in the provided dataset.")
     if target not in data.columns:
         raise KeyError(f"Target column '{target}' does not exist in provided dataset.")
     if data.mcol is None:
@@ -160,9 +160,9 @@ def _check_boundaries(x_pixels, y_pixels, x_min, x_max, y_min, y_max):
         if the specified `x` and `y` minimum and maximum values result in an invalid region.
     """
     if x_max - x_min <= 0:
-        raise ValueError("`xmax` must be greater than `xmin`!")
+        raise ValueError("`x_max` must be greater than `x_min`!")
     if y_max - y_min <= 0:
-        raise ValueError("`ymax` must be greater than `ymin`!")
+        raise ValueError("`y_max` must be greater than `y_min`!")
     if x_pixels <= 0:
         raise ValueError("`x_pixels` must be greater than zero!")
     if y_pixels <= 0:

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -149,7 +149,7 @@ def render_2d(data: 'SarracenDataFrame',
     target: str
         Column label of the target smoothing data.
     x, y: str, optional
-        Column label of the y-directional axis. Defaults to the y-column detected in `data`.
+        Column label of the x & y directional axes. Defaults to the columns detected in `data`.
     kernel: BaseKernel, optional
         Kernel to use for smoothing the target data. Defaults to the kernel specified in `data`.
     x_pixels, y_pixels: int, optional
@@ -211,6 +211,61 @@ def streamlines(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[
                 rotation: np.ndarray = None, origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None,
                 x_min: float = None, x_max: float = None, y_min: float = None, y_max: float = None, ax: Axes = None,
                 backend: str='cpu', **kwargs) -> Axes:
+    """ Create an SPH interpolated streamline plot of a target vector.
+
+    Render the data within a SarracenDataFrame to a 2D matplotlib object, by rendering the values
+    of a target vector. The contributions of all particles near the rendered area are summed and
+    stored to a 2D grid for the x & y axes of the target vector. This data is then used to create
+    a streamline plot using ax.streamlines().
+
+    Parameters
+    ----------
+    data : SarracenDataFrame
+        Particle data, in a SarracenDataFrame.
+    target: str tuple of shape (2) or (3).
+        Column label of the target vector. Shape must match the # of dimensions in `data`.
+    z_slice: float
+        The z to take a cross-section at. If none, column interpolation is performed.
+    x, y, z: str, optional
+        Column label of the x, y & z directional axes. Defaults to the columns detected in `data`.
+    kernel: BaseKernel, optional
+        Kernel to use for smoothing the target data. Defaults to the kernel specified in `data`.
+    integral_samples: int, optional
+        If using column interpolation, the number of sample points to take when approximating the 2D column kernel.
+    rotation: array_like or Rotation, optional
+        The rotation to apply to the data before interpolation. If defined as an array, the
+        order of rotations is [z, y, x] in degrees.
+    origin: array_like, optional
+        Point of rotation of the data, in [x, y, z] form. Defaults to the centre
+        point of the bounds of the data.
+    x_pixels, y_pixels: int, optional
+        Number of interpolation samples to pass to ax.streamlines(). Default values are chosen to keep
+        a consistent aspect ratio.
+    x_min, x_max, y_min, y_max: float, optional
+        The minimum and maximum values to use in interpolation, in particle data space. Defaults
+        to the minimum and maximum values of `x` and `y`.
+    ax: Axes
+        The main axes in which to draw the rendered image.
+    kwargs: other keyword arguments
+        Keyword arguments to pass to ax.streamlines()
+
+    Returns
+    -------
+    Axes
+        The resulting matplotlib axes, which contains the streamline plot.
+
+    Raises
+    ------
+    ValueError
+        If `x_pixels` or `y_pixels` are less than or equal to zero, or
+        if the specified `x` and `y` minimum and maximums result in an invalid region, or
+        if the number of dimensions in the target vector does not match the data, or
+        if `data` is not 2 or 3 dimensional.
+    KeyError
+        If `target`, `x`, `y`, `z` (for 3-dimensional data), mass, density, or smoothing length columns do not
+        exist in `data`.
+    """
+    # Choose between the various interpolation functions available, based on initial data passed to this function.
     if data.get_dim() == 2:
         if not len(target) == 2:
             raise ValueError('Target vector is not 2-dimensional.')
@@ -254,10 +309,63 @@ def streamlines(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[
 
 
 def arrowplot(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[str, str, str]], z_slice: int = None,
-                x: str = None, y: str = None, z: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
-                rotation: np.ndarray = None, origin: np.ndarray = None, x_arrows: int = None, y_arrows: int = None,
-                x_min: float = None, x_max: float = None, y_min: float = None, y_max: float = None, ax: Axes = None,
-                backend: str='cpu', **kwargs) -> Axes:
+              x: str = None, y: str = None, z: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
+              rotation: np.ndarray = None, origin: np.ndarray = None, x_arrows: int = None, y_arrows: int = None,
+              x_min: float = None, x_max: float = None, y_min: float = None, y_max: float = None, ax: Axes = None,
+              backend: str='cpu', **kwargs) -> Axes:
+    """ Create an SPH interpolated vector field plot of a target vector.
+
+    Render the data within a SarracenDataFrame to a 2D matplotlib object, by rendering the values
+    of a target vector. The contributions of all particles near the rendered area are summed and
+    stored to a 2D grid for the x & y axes of the target vector. This data is then used to create
+    an arrow plot using ax.quiver().
+
+    Parameters
+    ----------
+    data : SarracenDataFrame
+        Particle data, in a SarracenDataFrame.
+    target: str tuple of shape (2) or (3).
+        Column label of the target vector. Shape must match the # of dimensions in `data`.
+    z_slice: float
+        The z to take a cross-section at. If none, column interpolation is performed.
+    x, y, z: str, optional
+        Column label of the x, y & z directional axes. Defaults to the columns detected in `data`.
+    kernel: BaseKernel, optional
+        Kernel to use for smoothing the target data. Defaults to the kernel specified in `data`.
+    integral_samples: int, optional
+        If using column interpolation, the number of sample points to take when approximating the 2D column kernel.
+    rotation: array_like or Rotation, optional
+        The rotation to apply to the data before interpolation. If defined as an array, the order of rotations
+        is [z, y, x] in degrees.
+    origin: array_like, optional
+        Point of rotation of the data, in [x, y, z] form. Defaults to the centre point of the bounds of the data.
+    x_arrows, y_arrows: int, optional
+        Number of arrows in the output image in the x & y directions. Default values are chosen to keep
+        a consistent aspect ratio.
+    x_min, x_max, y_min, y_max: float, optional
+        The minimum and maximum values to use in interpolation, in particle data space. Defaults
+        to the minimum and maximum values of `x` and `y`.
+    ax: Axes
+        The main axes in which to draw the rendered image.
+    kwargs: other keyword arguments
+        Keyword arguments to pass to ax.quiver()
+
+    Returns
+    -------
+    Axes
+        The resulting matplotlib axes, which contains the arrow plot.
+
+    Raises
+    ------
+    ValueError
+        If `x_arrows` or `y_arrows` are less than or equal to zero, or
+        if the specified `x` and `y` minimum and maximums result in an invalid region, or
+        if the number of dimensions in the target vector does not match the data, or
+        if `data` is not 2 or 3 dimensional.
+    KeyError
+        If `target`, `x`, `y`, `z` (for 3-dimensional data), mass, density, or smoothing length columns do not
+        exist in `data`.
+    """
     x, y = _default_axes(data, x, y)
     x_min, x_max, y_min, y_max = _default_bounds(data, x, y, x_min, x_max, y_min, y_max)
     x_arrows, y_arrows = _set_pixels(x_arrows, y_arrows, x_min, x_max, y_min, y_max, 20)

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -8,7 +8,7 @@ Or, they can be accessed through a `SarracenDataFrame` object, for example:
     data.render_2d(target)
 """
 
-from typing import Union
+from typing import Union, Tuple
 
 import numpy as np
 import seaborn as sns
@@ -206,56 +206,27 @@ def render_2d(data: 'SarracenDataFrame',
     return ax
 
 
-def render_2d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, x: str = None, y: str = None,
-                  kernel: BaseKernel = None, x_pixels: int = None, y_pixels: int = None, x_min: float = None,
-                  x_max: float = None, y_min: float = None, y_max: float = None, plot_type: str = 'stream',
-                  ax: Axes = None, backend: str='cpu', **kwargs) -> Axes:
-    """ Render 2D vector particle data to a 2D grid, using SPH rendering of a target variable.
-
-        Render the data within a SarracenDataFrame to a 2D matplotlib object, by rendering the values
-        of a target vector. The contributions of all particles near the rendered area are summed and
-        stored to a 2D grid.
-
-        Parameters
-        ----------
-        data : SarracenDataFrame
-            Particle data, in a SarracenDataFrame.
-        target_x, target_y: str
-            Column labels of the target vector.
-        x, y: str, optional
-            Column label of the y-directional axis. Defaults to the y-column detected in `data`.
-        kernel: BaseKernel, optional
-            Kernel to use for smoothing the target data. Defaults to the kernel specified in `data`.
-        x_pixels, y_pixels: int, optional
-            Number of pixels in the output image in the x & y directions. Default values are chosen to keep
-            a consistent aspect ratio.
-        x_min, x_max, y_min, y_max: float, optional
-            The minimum and maximum values to use in interpolation, in particle data space. Defaults
-            to the minimum and maximum values of `x` and `y`.
-        plot_type: ['stream', 'arrow'], optional
-            The method of representing the interpolated vector. 'stream' uses ax.streamplot(), and `arrow` uses
-            ax.quiver().
-        ax: Axes
-            The main axes in which to draw the rendered image.
-        kwargs: other keyword arguments
-            Keyword arguments to pass to matplotlib.axes.Axes.imshow().
-
-        Returns
-        -------
-        Axes
-            The resulting matplotlib axes, which contain the 2d rendered image.
-
-        Raises
-        -------
-        ValueError
-            If `x_pixels` or `y_pixels` are less than or equal to zero, or
-            if the specified `x` and `y` minimum and maximums result in an invalid region.
-        KeyError
-            If `target_x`, `target_y`, `x`, `y`, mass, density, or smoothing length columns do not
-            exist in `data`.
-        """
-    img = interpolate_2d_vec(data, target_x, target_y, x, y, kernel, x_pixels, y_pixels, x_min, x_max, y_min, y_max,
-                               backend)
+def streamlines(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[str, str, str]], z_slice: int = None,
+                x: str = None, y: str = None, z: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
+                rotation: np.ndarray = None, origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None,
+                x_min: float = None, x_max: float = None, y_min: float = None, y_max: float = None, ax: Axes = None,
+                backend: str='cpu', **kwargs) -> Axes:
+    if data.get_dim() == 2:
+        if not len(target) == 2:
+            raise ValueError('Target vector is not 2-dimensional.')
+        img = interpolate_2d_vec(data, target[0], target[1], x, y, kernel, x_pixels, y_pixels, x_min, x_max, y_min,
+                                 y_max, backend)
+    elif data.get_dim() == 3:
+        if not len(target) == 3:
+            raise ValueError('Target vector is not 3-dimensional.')
+        if z_slice is None:
+            img = interpolate_3d_vec(data, target[0], target[1], target[2], x, y, kernel, integral_samples, rotation,
+                                     origin, x_pixels, y_pixels, x_min, x_max, y_min, y_max, backend)
+        else:
+            img = interpolate_3d_cross_vec(data, target[0], target[1], target[2], z_slice, x, y, z, kernel, rotation,
+                                           origin, x_pixels, y_pixels, x_min, x_max, y_min, y_max, backend)
+    else:
+        raise ValueError('`data` is not a valid number of dimensions.')
 
     if ax is None:
         ax = plt.gca()
@@ -264,17 +235,72 @@ def render_2d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, x: st
     x_min, x_max, y_min, y_max = _default_bounds(data, x, y, x_min, x_max, y_min, y_max)
 
     kwargs.setdefault("color", 'black')
-    if plot_type == 'stream':
-        ax.streamplot(np.linspace(x_min, x_max, np.size(img[0], 1)), np.linspace(y_min, y_max, np.size(img[0], 0)),
-                      img[0], img[1],
-                      **kwargs)
-    elif plot_type == 'arrow':
-        kwargs.setdefault("angles", 'uv')
-        kwargs.setdefault("pivot", 'mid')
-        ax.quiver(np.linspace(x_min, x_max, np.size(img[0], 1)), np.linspace(y_min, y_max, np.size(img[0], 0)), img[0],
-                  img[1], **kwargs)
+    ax.streamplot(np.linspace(x_min, x_max, np.size(img[0], 1)), np.linspace(y_min, y_max, np.size(img[0], 0)),
+                  img[0], img[1], **kwargs)
+
     ax.set_xlim(x_min, x_max)
     ax.set_ylim(y_min, y_max)
+
+    # remove the x & y ticks if the data is rotated, since these no longer have physical
+    # relevance to the displayed data.
+    if rotation is not None:
+        ax.set_xticks([])
+        ax.set_yticks([])
+    else:
+        ax.set_xlabel(x)
+        ax.set_ylabel(y)
+
+    return ax
+
+
+def arrowplot(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[str, str, str]], z_slice: int = None,
+                x: str = None, y: str = None, z: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
+                rotation: np.ndarray = None, origin: np.ndarray = None, x_arrows: int = None, y_arrows: int = None,
+                x_min: float = None, x_max: float = None, y_min: float = None, y_max: float = None, ax: Axes = None,
+                backend: str='cpu', **kwargs) -> Axes:
+    x, y = _default_axes(data, x, y)
+    x_min, x_max, y_min, y_max = _default_bounds(data, x, y, x_min, x_max, y_min, y_max)
+    x_arrows, y_arrows = _set_pixels(x_arrows, y_arrows, x_min, x_max, y_min, y_max, 20)
+
+    if data.get_dim() == 2:
+        if not len(target) == 2:
+            raise ValueError('Target vector is not 2-dimensional.')
+        img = interpolate_2d_vec(data, target[0], target[1], x, y, kernel, x_arrows, y_arrows, x_min, x_max, y_min,
+                                 y_max, backend)
+    elif data.get_dim() == 3:
+        if not len(target) == 3:
+            raise ValueError('Target vector is not 3-dimensional.')
+        if z_slice is None:
+            img = interpolate_3d_vec(data, target[0], target[1], target[2], x, y, kernel, integral_samples, rotation,
+                                     origin, x_arrows, y_arrows, x_min, x_max, y_min, y_max, backend)
+        else:
+            img = interpolate_3d_cross_vec(data, target[0], target[1], target[2], z_slice, x, y, z, kernel, rotation,
+                                           origin, x_arrows, y_arrows, x_min, x_max, y_min, y_max, backend)
+    else:
+        raise ValueError('`data` is not a valid number of dimensions.')
+
+    if ax is None:
+        ax = plt.gca()
+
+    x, y = _default_axes(data, x, y)
+    x_min, x_max, y_min, y_max = _default_bounds(data, x, y, x_min, x_max, y_min, y_max)
+
+    kwargs.setdefault("angles", 'uv')
+    kwargs.setdefault("pivot", 'mid')
+    ax.quiver(np.linspace(x_min, x_max, np.size(img[0], 1)), np.linspace(y_min, y_max, np.size(img[0], 0)), img[0],
+              img[1], **kwargs)
+
+    ax.set_xlim(x_min, x_max)
+    ax.set_ylim(y_min, y_max)
+
+    # remove the x & y ticks if the data is rotated, since these no longer have physical
+    # relevance to the displayed data.
+    if rotation is not None:
+        ax.set_xticks([])
+        ax.set_yticks([])
+    else:
+        ax.set_xlabel(x)
+        ax.set_ylabel(y)
 
     return ax
 
@@ -455,97 +481,6 @@ def render_3d(data: 'SarracenDataFrame',
     return ax
 
 
-def render_3d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, target_z: str, x: str = None, y: str = None,
-                  kernel: BaseKernel = None, integral_samples: int = 1000, rotation: np.ndarray = None,
-                  origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None, x_min: float = None,
-                  x_max: float = None, y_min: float = None, y_max: float = None, plot_type: str = 'stream',
-                  ax: Axes = None, backend: str = None, **kwargs) -> Axes:
-    """ Render 3D vector particle data to a 2D grid, using SPH column rendering of a target vector.
-
-        Render the data within a SarracenDataFrame to a 2D matplotlib object, by rendering the values
-        of a target vector. The contributions of all particles near columns across the z-axis are
-        summed and stored in a to a 2D grid.
-
-        Parameters
-        ----------
-        data : SarracenDataFrame
-            Particle data, in a SarracenDataFrame.
-        target_x, target_y, target_z: str
-            Column labels of the target vector.
-        x, y: str
-            Column labels of the directional axes. Defaults to the x & y columns detected in `data`.
-        kernel: BaseKernel, optional
-            Kernel to use for smoothing the target data. Defaults to the kernel specified in `data`.
-        integral_samples: int, optional
-            The number of sample points to take when approximating the 2D column kernel.
-        rotation: array_like or Rotation, optional
-            The rotation to apply to the data before interpolation. If defined as an array, the
-            order of rotations is [z, y, x] in degrees.
-        origin: array_like, optional
-            Point of rotation of the data, in [x, y, z] form. Defaults to the centre
-            point of the bounds of the data.
-        x_pixels, y_pixels: int, optional
-            Number of pixels in the output image in the x & y directions. Default values are chosen to keep
-            a consistent aspect ratio.
-        x_min, x_max, y_min, y_max: float, optional
-            The minimum and maximum values to render over, in particle data space. Defaults
-            to the minimum and maximum values of `x` and `y`.
-        plot_type: ['stream', 'arrow'], optional
-            The method of representing the interpolated vector. 'stream' uses ax.streamplot(), and `arrow` uses
-            ax.quiver().
-        ax: Axes
-            The main axes in which to draw the rendered image.
-        kwargs: other keyword arguments
-            Keyword arguments to pass to matplotlib.axes.Axes.imshow().
-
-        Returns
-        -------
-        Axes
-            The resulting matplotlib axes, which contains the 2d rendered image.
-
-        Raises
-        -------
-        ValueError
-            If `x_pixels` or `y_pixels` are less than or equal to zero, or
-            if the specified `x` and `y` minimum and maximums result in an invalid region, or
-            if the provided data is not 3-dimensional.
-        KeyError
-            If `target_x`, `target_y`, `target_z`, `x`, `y`, mass, density, or smoothing length columns do not
-            exist in `data`.
-        """
-    img = interpolate_3d_vec(data, target_x, target_y, target_z, x, y, kernel, integral_samples, rotation, origin,
-                             x_pixels, y_pixels, x_min, x_max, y_min, y_max, backend)
-
-    if ax is None:
-        ax = plt.gca()
-
-    x, y = _default_axes(data, x, y)
-    x_min, x_max, y_min, y_max = _default_bounds(data, x, y, x_min, x_max, y_min, y_max)
-
-    kwargs.setdefault("color", 'black')
-    if plot_type == 'stream':
-        ax.streamplot(np.linspace(x_min, x_max, np.size(img[0], 1)), np.linspace(y_min, y_max, np.size(img[0], 0)),
-                      img[0], img[1], **kwargs)
-    elif plot_type == 'arrow':
-        kwargs.setdefault("angles", 'uv')
-        kwargs.setdefault("pivot", 'mid')
-        ax.quiver(np.linspace(x_min, x_max, np.size(img[0], 1)), np.linspace(y_min, y_max, np.size(img[0], 0)), img[0],
-                  img[1], **kwargs)
-    ax.set_xlim(x_min, x_max)
-    ax.set_ylim(y_min, y_max)
-
-    # remove the x & y ticks if the data is rotated, since these no longer have physical
-    # relevance to the displayed data.
-    if rotation is not None:
-        ax.set_xticks([])
-        ax.set_yticks([])
-    else:
-        ax.set_xlabel(x)
-        ax.set_ylabel(y)
-
-    return ax
-
-
 def render_3d_cross(data: 'SarracenDataFrame',
                     target: str,
                     z_slice: float = None,
@@ -651,98 +586,5 @@ def render_3d_cross(data: 'SarracenDataFrame',
     if cbar:
         colorbar = ax.figure.colorbar(graphic, cbar_ax, ax, **cbar_kws)
         colorbar.ax.set_ylabel(target)
-
-    return ax
-
-
-def render_3d_cross_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, target_z: str, z_slice: float = None,
-                        x: str = None, y: str = None, z: str = None, kernel: BaseKernel = None,
-                        rotation: np.ndarray = None, origin: np.ndarray = None, x_pixels: int = None,
-                        y_pixels: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
-                        y_max: float = None, plot_type: str = 'stream', ax: Axes = None, backend: str = None, **kwargs)\
-                        -> Axes:
-    """ Render 3D vector particle data to a 2D grid, using a 3D cross-section.
-
-        Render the data within a SarracenDataFrame to a 2D matplotlib object, using a 3D -> 2D
-        cross-section of the target vector. The cross-section is taken of the 3D data at a specific
-        value of z, and the contributions of particles near the plane are interpolated to a 2D grid.
-
-        Parameters
-        ----------
-        data : SarracenDataFrame
-            The particle data to render.
-        target_x, target_y, target_z: str
-            The column labels of the target vector.
-        z_slice: float
-            The z-axis value to take the cross-section at. Defaults to the midpoint of the z-directional data.
-        x, y, z: str
-            The column labels of the directional data to render. Defaults to the x, y, and z columns
-            detected in `data`.
-        kernel: BaseKernel
-            The kernel to use for smoothing the target data. Defaults to the kernel specified in `data`.
-        rotation: array_like or Rotation, optional
-            The rotation to apply to the data before rendering. If defined as an array, the
-            order of rotations is [z, y, x] in degrees.
-        origin: array_like, optional
-            Point of rotation of the data, in [x, y, z] form. Defaults to the centre
-            point of the bounds of the data.
-        x_pixels, y_pixels: int, optional
-            Number of pixels in the output image in the x & y directions. Default values are chosen to keep
-            a consistent aspect ratio.
-        x_min, x_max, y_min, y_max: float, optional
-            The minimum and maximum values to render over, in particle data space. Defaults
-            to the minimum and maximum values of `x` and `y`.
-        plot_type: ['stream', 'arrow'], optional
-            The method of representing the interpolated vector. 'stream' uses ax.streamplot(), and `arrow` uses
-            ax.quiver().
-        ax: Axes
-            The main axes in which to draw the rendered image.
-        kwargs: other keyword arguments
-            Keyword arguments to pass to matplotlib.axes.Axes.imshow().
-
-        Returns
-        -------
-        Axes
-            The resulting matplotlib axes object, containing the 3d cross-section image.
-
-        Raises
-        -------
-        ValueError
-            If `x_pixels` or `y_pixels` are less than or equal to zero, or
-            if the specified `x` and `y` minimum and maximums result in an invalid region, or
-            if the provided data is not 3-dimensional.
-        KeyError
-            If `target_x`, `target_y`, `target_z`, `x`, `y`, `z`, mass, density, or smoothing length columns do not
-            exist in `data`.
-        """
-    img = interpolate_3d_cross_vec(data, target_x, target_y, target_z, z_slice, x, y, z, kernel, rotation, origin,
-                                   x_pixels, y_pixels, x_min, x_max, y_min, y_max, backend)
-
-    if ax is None:
-        ax = plt.gca()
-
-    x, y = _default_axes(data, x, y)
-    x_min, x_max, y_min, y_max = _default_bounds(data, x, y, x_min, x_max, y_min, y_max)
-
-    kwargs.setdefault("color", 'black')
-    if plot_type == 'stream':
-        ax.streamplot(np.linspace(x_min, x_max, np.size(img[0], 1)), np.linspace(y_min, y_max, np.size(img[0], 0)),
-                      img[0], img[1], **kwargs)
-    elif plot_type == 'arrow':
-        kwargs.setdefault("angles", 'uv')
-        kwargs.setdefault("pivot", 'mid')
-        ax.quiver(np.linspace(x_min, x_max, np.size(img[0], 1)), np.linspace(y_min, y_max, np.size(img[0], 0)), img[0],
-                  img[1], **kwargs)
-    ax.set_xlim(x_min, x_max)
-    ax.set_ylim(y_min, y_max)
-
-    # remove the x & y ticks if the data is rotated, since these no longer have physical
-    # relevance to the displayed data.
-    if rotation is not None:
-        ax.set_xticks([])
-        ax.set_yticks([])
-    else:
-        ax.set_xlabel(x)
-        ax.set_ylabel(y)
 
     return ax

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -253,10 +253,10 @@ class SarracenDataFrame(DataFrame):
 
     @_copy_doc(render_3d_cross_vec)
     def render_3d_cross_vec(self, target_x: str, target_y: str, target_z: str, z_slice: float = None, x: str = None,
-                      y: str = None, z: str = None, kernel: BaseKernel = None, rotation: np.ndarray = None,
-                      origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None, x_min: float = None,
-                      x_max: float = None, y_min: float = None, y_max: float = None, plot_type: str = 'stream',
-                      ax: Axes = None, backend: str = None, **kwargs) -> Axes:
+                            y: str = None, z: str = None, kernel: BaseKernel = None, rotation: np.ndarray = None,
+                            origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None, x_min: float = None,
+                            x_max: float = None, y_min: float = None, y_max: float = None, plot_type: str = 'stream',
+                            ax: Axes = None, backend: str = None, **kwargs) -> Axes:
         return render_3d_cross_vec(self, target_x, target_y, target_z, z_slice, x, y, z, kernel, rotation, origin,
                                    x_pixels, y_pixels, x_min, x_max, y_min, y_max, plot_type, ax, backend, **kwargs)
 

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -1,4 +1,4 @@
-from typing import Union, Callable
+from typing import Union, Callable, Tuple
 
 from matplotlib.axes import Axes
 from matplotlib.colors import Colormap
@@ -6,8 +6,7 @@ from pandas import DataFrame, Series
 import numpy as np
 from scipy.spatial.transform import Rotation as R
 
-from sarracen.render import render_2d, render_2d_cross, render_3d, render_3d_cross, render_3d_vec, render_3d_cross_vec, \
-    render_2d_vec
+from sarracen.render import render_2d, render_2d_cross, render_3d, render_3d_cross, streamlines, arrowplot
 from sarracen.kernels import CubicSplineKernel, BaseKernel
 
 
@@ -167,14 +166,6 @@ class SarracenDataFrame(DataFrame):
 
         return render_2d(self, target, x, y, kernel, x_pixels, y_pixels, x_min, x_max, y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, **kwargs)
 
-    @_copy_doc(render_2d_vec)
-    def render_2d_vec(self, target_x: str, target_y: str, x: str = None, y: str = None, kernel: BaseKernel = None,
-                      x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None,
-                      y_min: float = None, y_max: float = None, plot_type: str = 'stream', ax: Axes = None,
-                      backend: str = None, **kwargs) -> Axes:
-        return render_2d_vec(self, target_x, target_y, x, y, kernel, x_pixels, y_pixels, x_min, x_max, y_min, y_max,
-                             plot_type, ax, backend, **kwargs)
-
     @_copy_doc(render_2d_cross)
     def render_2d_cross(self,
                         target: str,
@@ -216,15 +207,6 @@ class SarracenDataFrame(DataFrame):
         return render_3d(self, target, x, y, kernel, int_samples, rotation, origin, x_pixels, y_pixels, x_min, x_max, y_min, y_max,
                          cmap, cbar, cbar_kws, cbar_ax, ax, **kwargs)
 
-    @_copy_doc(render_3d_vec)
-    def render_3d_vec(self, target_x: str, target_y: str, target_z: str, x: str = None, y: str = None,
-                      kernel: BaseKernel = None, int_samples: int = 1000, rotation: np.ndarray = None,
-                      origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None, x_min: float = None,
-                      x_max: float = None, y_min: float = None, y_max: float = None, plot_type: str = 'stream',
-                      ax: Axes = None, backend: str = None, **kwargs) -> Axes:
-        return render_3d_vec(self, target_x, target_y, target_z, x, y, kernel, int_samples, rotation, origin, x_pixels,
-                             y_pixels, x_min, x_max, y_min, y_max, plot_type, ax, backend, **kwargs)
-
     @_copy_doc(render_3d_cross)
     def render_3d_cross(self,
                         target: str,
@@ -251,14 +233,23 @@ class SarracenDataFrame(DataFrame):
         return render_3d_cross(self, target, z_slice, x, y, z, kernel, rotation, origin, x_pixels, y_pixels, x_min,
                                x_max, y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, **kwargs)
 
-    @_copy_doc(render_3d_cross_vec)
-    def render_3d_cross_vec(self, target_x: str, target_y: str, target_z: str, z_slice: float = None, x: str = None,
-                            y: str = None, z: str = None, kernel: BaseKernel = None, rotation: np.ndarray = None,
-                            origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None, x_min: float = None,
-                            x_max: float = None, y_min: float = None, y_max: float = None, plot_type: str = 'stream',
-                            ax: Axes = None, backend: str = None, **kwargs) -> Axes:
-        return render_3d_cross_vec(self, target_x, target_y, target_z, z_slice, x, y, z, kernel, rotation, origin,
-                                   x_pixels, y_pixels, x_min, x_max, y_min, y_max, plot_type, ax, backend, **kwargs)
+    @_copy_doc(streamlines)
+    def streamlines(self, target: Union[Tuple[str, str], Tuple[str, str, str]], z_slice: int = None, x: str = None,
+                    y: str = None, z: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
+                    rotation: np.ndarray = None, origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None,
+                    x_min: float = None, x_max: float = None, y_min: float = None, y_max: float = None, ax: Axes = None,
+                    backend: str='cpu', **kwargs) -> Axes:
+        return streamlines(self, target, z_slice, x, y, z, kernel, integral_samples, rotation, origin, x_pixels,
+                           y_pixels, x_min, x_max, y_min, y_max, ax, backend, **kwargs)
+
+    @_copy_doc(arrowplot)
+    def arrowplot(self, target: Union[Tuple[str, str], Tuple[str, str, str]], z_slice: int = None, x: str = None,
+                  y: str = None, z: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
+                  rotation: np.ndarray = None, origin: np.ndarray = None, x_arrows: int = None, y_arrows: int = None,
+                  x_min: float = None, x_max: float = None, y_min: float = None, y_max: float = None, ax: Axes = None,
+                  backend: str='cpu', **kwargs) -> Axes:
+        return arrowplot(self, target, z_slice, x, y, z, kernel, integral_samples, rotation, origin, x_arrows, y_arrows,
+                         x_min, x_max, y_min, y_max, ax, backend, **kwargs)
 
     @property
     def params(self):

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -6,7 +6,8 @@ from pandas import DataFrame, Series
 import numpy as np
 from scipy.spatial.transform import Rotation as R
 
-from sarracen.render import render_2d, render_2d_cross, render_3d, render_3d_cross
+from sarracen.render import render_2d, render_2d_cross, render_3d, render_3d_cross, render_3d_vec, render_3d_cross_vec, \
+    render_2d_vec
 from sarracen.kernels import CubicSplineKernel, BaseKernel
 
 
@@ -166,6 +167,14 @@ class SarracenDataFrame(DataFrame):
 
         return render_2d(self, target, x, y, kernel, x_pixels, y_pixels, x_min, x_max, y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, **kwargs)
 
+    @_copy_doc(render_2d_vec)
+    def render_2d_vec(self, target_x: str, target_y: str, x: str = None, y: str = None, kernel: BaseKernel = None,
+                      x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None,
+                      y_min: float = None, y_max: float = None, plot_type: str = 'stream', ax: Axes = None,
+                      backend: str = None, **kwargs) -> Axes:
+        return render_2d_vec(self, target_x, target_y, x, y, kernel, x_pixels, y_pixels, x_min, x_max, y_min, y_max,
+                             plot_type, ax, backend, **kwargs)
+
     @_copy_doc(render_2d_cross)
     def render_2d_cross(self,
                         target: str,
@@ -207,6 +216,15 @@ class SarracenDataFrame(DataFrame):
         return render_3d(self, target, x, y, kernel, int_samples, rotation, origin, x_pixels, y_pixels, x_min, x_max, y_min, y_max,
                          cmap, cbar, cbar_kws, cbar_ax, ax, **kwargs)
 
+    @_copy_doc(render_3d_vec)
+    def render_3d_vec(self, target_x: str, target_y: str, target_z: str, x: str = None, y: str = None,
+                      kernel: BaseKernel = None, int_samples: int = 1000, rotation: np.ndarray = None,
+                      origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None, x_min: float = None,
+                      x_max: float = None, y_min: float = None, y_max: float = None, plot_type: str = 'stream',
+                      ax: Axes = None, backend: str = None, **kwargs) -> Axes:
+        return render_3d_vec(self, target_x, target_y, target_z, x, y, kernel, int_samples, rotation, origin, x_pixels,
+                             y_pixels, x_min, x_max, y_min, y_max, plot_type, ax, backend, **kwargs)
+
     @_copy_doc(render_3d_cross)
     def render_3d_cross(self,
                         target: str,
@@ -232,6 +250,15 @@ class SarracenDataFrame(DataFrame):
 
         return render_3d_cross(self, target, z_slice, x, y, z, kernel, rotation, origin, x_pixels, y_pixels, x_min,
                                x_max, y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, **kwargs)
+
+    @_copy_doc(render_3d_cross_vec)
+    def render_3d_cross_vec(self, target_x: str, target_y: str, target_z: str, z_slice: float = None, x: str = None,
+                      y: str = None, z: str = None, kernel: BaseKernel = None, rotation: np.ndarray = None,
+                      origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None, x_min: float = None,
+                      x_max: float = None, y_min: float = None, y_max: float = None, plot_type: str = 'stream',
+                      ax: Axes = None, backend: str = None, **kwargs) -> Axes:
+        return render_3d_cross_vec(self, target_x, target_y, target_z, z_slice, x, y, z, kernel, rotation, origin,
+                                   x_pixels, y_pixels, x_min, x_max, y_min, y_max, plot_type, ax, backend, **kwargs)
 
     @property
     def params(self):

--- a/sarracen/tests/test_render.py
+++ b/sarracen/tests/test_render.py
@@ -8,7 +8,7 @@ from pytest import approx
 
 from sarracen import SarracenDataFrame
 from sarracen.kernels import CubicSplineKernel
-from sarracen.render import render_2d, render_2d_cross, render_3d, render_3d_cross
+from sarracen.render import render_2d, render_2d_cross, render_3d, render_3d_cross, render_3d_cross_vec
 
 
 def test_2d_plot():
@@ -128,12 +128,7 @@ def test_render_passthrough():
     # Basic tests that both sdf.render() and render(sdf) return the same plots
 
     # 2D dataset
-    df = pd.DataFrame({'x': [3, 6],
-                       'y': [5, 1],
-                       'P': [1, 1],
-                       'h': [1, 1],
-                       'rho': [1, 1],
-                       'm': [1, 1]})
+    df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf = SarracenDataFrame(df)
 
     fig1, ax1 = plt.subplots()
@@ -151,13 +146,8 @@ def test_render_passthrough():
     assert repr(ax1) == repr(ax2)
 
     # 3D dataset
-    df = pd.DataFrame({'x': [3, 6],
-                       'y': [5, 1],
-                       'z': [2, 1],
-                       'P': [1, 1],
-                       'h': [1, 1],
-                       'rho': [1, 1],
-                       'm': [1, 1]})
+    df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'Ax': [5, 3], 'Ay': [2, 3],
+                       'Az': [1, -1], 'rho': [1, 1], 'm': [1, 1]})
     sdf = SarracenDataFrame(df)
 
     fig1, ax1 = plt.subplots()
@@ -171,6 +161,20 @@ def test_render_passthrough():
     fig2, ax2 = plt.subplots()
     ax1 = sdf.render_3d_cross('P', ax=ax1)
     ax2 = render_3d_cross(sdf, 'P', ax=ax2)
+
+    assert repr(ax1) == repr(ax2)
+
+    fig1, ax1 = plt.subplots()
+    fig2, ax2 = plt.subplots()
+    ax1 = sdf.render_3d_cross_vec('Ax', 'Ay', 'Az', ax=ax1)
+    ax2 = render_3d_cross_vec(sdf, 'Ax', 'Ay', 'Az', ax=ax2)
+
+    assert repr(ax1) == repr(ax2)
+
+    fig1, ax1 = plt.subplots()
+    fig2, ax2 = plt.subplots()
+    ax1 = sdf.render_3d_cross_vec('Ax', 'Ay', 'Az', ax=ax1)
+    ax2 = render_3d_cross_vec(sdf, 'Ax', 'Ay', 'Az', ax=ax2)
 
     assert repr(ax1) == repr(ax2)
 


### PR DESCRIPTION
Introduces three new interpolation / render functions for visualizing vector data:

- 2D rendering of vector data in a 2D particle system.
- 3D column interpolation of vector data in a 3D particle system.
- 3D cross-sections of vector data in a 3D particle system.

Interpolated vector fields can be plotted in two ways. A streamline plot with `ax.streamplot`, or a vector field with arrows using `ax.quiver`.

An example of the two different plotting methods:

![image](https://user-images.githubusercontent.com/71343838/173411895-88c2bdb8-98d4-4402-8e31-3d23bd87f995.png)

Streamlines are on the left, arrows are on the right. cmap is set to 'hot'.