### PR TITLE
Advanced unit test suite

### DIFF
--- a/sarracen/interpolate.py
+++ b/sarracen/interpolate.py
@@ -812,7 +812,7 @@ def _fast_2d_cross(target, x_data, y_data, mass_data, rho_data, h_data, weight_f
 
 # Underlying CPU numba-compiled code for interpolation to a 2D grid. Used in interpolation of 2D data,
 # and column integration / cross-sections of 3D data.
-#@njit(parallel=True, fastmath=True)
+@njit(parallel=True, fastmath=True)
 def _fast_2d_cpu(target, z_slice, x_data, y_data, z_data, mass_data, rho_data, h_data, weight_function, kernel_radius,
                  x_pixels, y_pixels, x_min, x_max, y_min, y_max, n_dims):
     image = np.zeros((y_pixels, x_pixels))

--- a/sarracen/interpolate.py
+++ b/sarracen/interpolate.py
@@ -590,6 +590,7 @@ def interpolate_3d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, 
         Since the direction of integration is assumed to be straight across the z-axis, the z-axis column
         is not required for this type of interpolation.
         """
+    _check_dimension(data, 3)
     x, y = _default_xy(data, x, y)
     _verify_columns(data, x, y, target_x)
     _verify_columns(data, x, y, target_y)
@@ -606,7 +607,6 @@ def interpolate_3d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, 
 
     kernel = kernel if kernel is not None else data.kernel
     backend = backend if backend is not None else data.backend
-    _check_dimension(data, 3)
 
     weight_function = kernel.get_column_kernel_func(integral_samples)
     return (_fast_2d(target_x_data, 0, x_data, y_data, np.zeros(len(data)), data['m'].to_numpy(),
@@ -756,6 +756,7 @@ def interpolate_3d_cross_vec(data: 'SarracenDataFrame', target_x: str, target_y:
             If `target_x`, `target_y`, `target_z`, `x`, `y`, `z`, mass, density, or smoothing length columns do not
             exist in `data`.
         """
+    _check_dimension(data, 3)
     x, y = _default_xy(data, x, y)
     _verify_columns(data, x, y, target_x)
     _verify_columns(data, x, y, target_y)
@@ -780,7 +781,6 @@ def interpolate_3d_cross_vec(data: 'SarracenDataFrame', target_x: str, target_y:
 
     kernel = kernel if kernel is not None else data.kernel
     backend = backend if backend is not None else data.backend
-    _check_dimension(data, 3)
 
     return (_fast_2d(target_x_data, z_slice, x_data, y_data, z_data, data['m'].to_numpy(),
                      data['rho'].to_numpy(), data['h'].to_numpy(), kernel.w, kernel.get_radius(), x_pixels, y_pixels,
@@ -812,7 +812,7 @@ def _fast_2d_cross(target, x_data, y_data, mass_data, rho_data, h_data, weight_f
 
 # Underlying CPU numba-compiled code for interpolation to a 2D grid. Used in interpolation of 2D data,
 # and column integration / cross-sections of 3D data.
-@njit(parallel=True, fastmath=True)
+#@njit(parallel=True, fastmath=True)
 def _fast_2d_cpu(target, z_slice, x_data, y_data, z_data, mass_data, rho_data, h_data, weight_function, kernel_radius,
                  x_pixels, y_pixels, x_min, x_max, y_min, y_max, n_dims):
     image = np.zeros((y_pixels, x_pixels))

--- a/sarracen/interpolate.py
+++ b/sarracen/interpolate.py
@@ -187,7 +187,7 @@ def _check_dimension(data, dim):
         If the dataset is not `dim`-dimensional.
     """
     if data.get_dim() != dim:
-        raise ValueError(f"Dataset is not {dim}-dimensional.")
+        raise TypeError(f"Dataset is not {dim}-dimensional.")
 
 
 def _rotate_data(data, x, y, z, rotation, origin):
@@ -314,6 +314,7 @@ def interpolate_2d(data: 'SarracenDataFrame', target: str, x: str = None, y: str
         If `target`, `x`, `y`, mass, density, or smoothing length columns do not
         exist in `data`.
     """
+    _check_dimension(data, 2)
     x, y = _default_xy(data, x, y)
     _verify_columns(data, x, y, target)
 
@@ -323,7 +324,6 @@ def interpolate_2d(data: 'SarracenDataFrame', target: str, x: str = None, y: str
 
     kernel = kernel if kernel is not None else data.kernel
     backend = backend if backend is not None else data.backend
-    _check_dimension(data, 2)
 
     return _fast_2d(data[target].to_numpy(), 0, data[x].to_numpy(), data[y].to_numpy(), np.zeros(len(data)),
                     data['m'].to_numpy(), data['rho'].to_numpy(), data['h'].to_numpy(), kernel.w,
@@ -374,6 +374,7 @@ def interpolate_2d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, 
         If `target_x`, `target_y`, `x`, `y`, mass, density, or smoothing length columns do not
         exist in `data`.
     """
+    _check_dimension(data, 2)
     x, y = _default_xy(data, x, y)
     _verify_columns(data, x, y, target_x)
     _verify_columns(data, x, y, target_y)
@@ -384,7 +385,6 @@ def interpolate_2d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, 
 
     kernel = kernel if kernel is not None else data.kernel
     backend = backend if backend is not None else data.backend
-    _check_dimension(data, 2)
 
     return (_fast_2d(data[target_x].to_numpy(), 0, data[x].to_numpy(), data[y].to_numpy(), np.zeros(len(data)),
                      data['m'].to_numpy(), data['rho'].to_numpy(), data['h'].to_numpy(), kernel.w,
@@ -394,17 +394,9 @@ def interpolate_2d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, 
                     kernel.get_radius(), x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2, backend))
 
 
-def interpolate_2d_cross(data: 'SarracenDataFrame',
-                         target: str,
-                         x: str = None,
-                         y: str = None,
-                         kernel: BaseKernel = None,
-                         pixels: int = None,
-                         x1: float = None,
-                         x2: float = None,
-                         y1: float = None,
-                         y2: float = None,
-                         backend: str = None) -> np.ndarray:
+def interpolate_2d_cross(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None,
+                         kernel: BaseKernel = None, pixels: int = 512, x1: float = None, x2: float = None,
+                         y1: float = None, y2: float = None, backend: str = None) -> np.ndarray:
     """ Interpolate particle data across two directional axes to a 1D cross-section line.
 
     Interpolate the data within a SarracenDataFrame to a 1D line, by interpolating the values
@@ -444,6 +436,7 @@ def interpolate_2d_cross(data: 'SarracenDataFrame',
         If `target`, `x`, `y`, mass, density, or smoothing length columns do not
         exist in `data`.
     """
+    _check_dimension(data, 2)
     x, y = _default_xy(data, x, y)
     _verify_columns(data, x, y, target)
 
@@ -453,7 +446,6 @@ def interpolate_2d_cross(data: 'SarracenDataFrame',
 
     kernel = kernel if kernel is not None else data.kernel
     backend = backend if backend is not None else data.backend
-    _check_dimension(data, 2)
 
     if pixels <= 0:
         raise ValueError('pixcount must be greater than zero!')
@@ -521,6 +513,7 @@ def interpolate_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str
     Since the direction of integration is assumed to be straight across the z-axis, the z-axis column
     is not required for this type of interpolation.
     """
+    _check_dimension(data, 3)
     x, y = _default_xy(data, x, y)
     _verify_columns(data, x, y, target)
 
@@ -531,7 +524,6 @@ def interpolate_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str
     x_data, y_data, _ = _rotate_xyz(data, x, y, data.zcol, rotation, origin)
     kernel = kernel if kernel is not None else data.kernel
     backend = backend if backend is not None else data.backend
-    _check_dimension(data, 3)
 
     weight_function = kernel.get_column_kernel_func(integral_samples)
 
@@ -679,6 +671,8 @@ def interpolate_3d_cross(data: 'SarracenDataFrame', target: str, z_slice: float 
         If `target`, `x`, `y`, `z`, mass, density, or smoothing length columns do not
         exist in `data`.
     """
+    _check_dimension(data, 3)
+
     # x & y columns default to the variables determined by the SarracenDataFrame.
     x, y = _default_xy(data, x, y)
     _verify_columns(data, target, x, y)
@@ -700,9 +694,7 @@ def interpolate_3d_cross(data: 'SarracenDataFrame', target: str, z_slice: float 
     kernel = kernel if kernel is not None else data.kernel
     backend = backend if backend is not None else data.backend
 
-    _check_dimension(data, 3)
-
-    x_data, y_data, z_data = _rotate_xyz(data, x, y, data.zcol, rotation, origin)
+    x_data, y_data, z_data = _rotate_xyz(data, x, y, z, rotation, origin)
 
     return _fast_2d(data[target].to_numpy(), z_slice, x_data, y_data, z_data, data['m'].to_numpy(),
                     data['rho'].to_numpy(), data['h'].to_numpy(), kernel.w, kernel.get_radius(), x_pixels, y_pixels,

--- a/sarracen/kernels/base_kernel.py
+++ b/sarracen/kernels/base_kernel.py
@@ -87,8 +87,8 @@ class BaseKernel:
             # using np.linspace() would break compatibility with the GPU backend,
             # so the calculation here is performed manually.
             wab_index = q * (samples - 1) / radius
-            index = int(math.floor(wab_index))
-            index1 = int(math.ceil(wab_index))
+            index = min(max(0, int(math.floor(wab_index))), samples - 1)
+            index1 = min(max(0, int(math.ceil(wab_index))), samples - 1)
             t = wab_index - index
             return column_kernel[index] * (1 - t) + column_kernel[index1] * t
 

--- a/sarracen/kernels/cubic_spline.py
+++ b/sarracen/kernels/cubic_spline.py
@@ -16,5 +16,5 @@ class CubicSplineKernel(BaseKernel):
     def w(q: float, ndim: int):
         norm = 2 / 3 if (ndim == 1) else 10 / (7 * np.pi) if (ndim == 2) else 1 / np.pi
 
-        return norm * ((1 - (3. / 2.) * q ** 2 + (3. / 4.) * q ** 3) * (q < 1)
-                       + (1. / 4.) * (2 - q) ** 3 * (q < 2) * (q >= 1))
+        return norm * ((1 - (3. / 2.) * q ** 2 + (3. / 4.) * q ** 3) * (0 <= q) * (q < 1)
+                       + (1. / 4.) * (2 - q) ** 3 * (1 <= q) * (q < 2))

--- a/sarracen/kernels/quartic_spline.py
+++ b/sarracen/kernels/quartic_spline.py
@@ -18,5 +18,6 @@ class QuarticSplineKernel(BaseKernel):
             96 / (1199 * np.pi) if (ndim == 2) else \
             1 / (20 * np.pi)
 
-        return norm * (((5 / 2) - q) ** 4 * (q < 2.5) - 5 * ((3 / 2) - q) ** 4 * (q < 1.5) + 10 * ((1 / 2) - q) ** 4 * (
-                    q < 0.5))
+        return norm * (((5 / 2) - q) ** 4 * (q < 2.5)
+                       - 5 * ((3 / 2) - q) ** 4 * (q < 1.5)
+                       + 10 * ((1 / 2) - q) ** 4 * ( q < 0.5)) * (0 <= q)

--- a/sarracen/kernels/quintic_spline.py
+++ b/sarracen/kernels/quintic_spline.py
@@ -18,4 +18,6 @@ class QuinticSplineKernel(BaseKernel):
             7 / (478 * np.pi) if (ndim == 2) else \
             1 / (120 * np.pi)
 
-        return norm * ((3 - q) ** 5 * (q < 3) - 6 * (2 - q) ** 5 * (q < 2) + 15 * (1 - q) ** 5 * (q < 1))
+        return norm * ((3 - q) ** 5 * (q < 3)
+                       - 6 * (2 - q) ** 5 * (q < 2)
+                       + 15 * (1 - q) ** 5 * (q < 1)) * (0 <= q)

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -469,7 +469,7 @@ def render_2d_cross(data: 'SarracenDataFrame', target: str, x: str = None, y: st
 
 
 def render_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None, kernel: BaseKernel = None,
-              integral_samples: int = 1000, rotation: np.ndarray = None, origin: np.ndarray = None,
+              integral_samples: int = 1000, rotation: np.ndarray = None, rot_origin: np.ndarray = None,
               x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
               y_max: float = None, cmap: Union[str, Colormap] = 'RdBu', cbar: bool = True, cbar_kws: dict = {},
               cbar_ax: Axes = None, ax: Axes = None, backend: str = None, **kwargs) -> Axes:
@@ -494,7 +494,7 @@ def render_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = No
     rotation: array_like or Rotation, optional
         The rotation to apply to the data before interpolation. If defined as an array, the
         order of rotations is [z, y, x] in degrees.
-    origin: array_like, optional
+    rot_origin: array_like, optional
         Point of rotation of the data, in [x, y, z] form. Defaults to the centre
         point of the bounds of the data.
     x_pixels, y_pixels: int, optional
@@ -533,7 +533,7 @@ def render_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = No
         If `target`, `x`, `y`, mass, density, or smoothing length columns do not
         exist in `data`.
     """
-    image = interpolate_3d(data, target, x, y, kernel, integral_samples, rotation, origin, x_pixels, y_pixels, x_min,
+    image = interpolate_3d(data, target, x, y, kernel, integral_samples, rotation, rot_origin, x_pixels, y_pixels, x_min,
                            x_max, y_min, y_max, backend)
 
     if ax is None:
@@ -563,10 +563,11 @@ def render_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = No
 
 
 def render_3d_cross(data: 'SarracenDataFrame', target: str, z_slice: float = None, x: str = None, y: str = None,
-                    z: str = None, kernel: BaseKernel = None, rotation: np.ndarray = None, origin: np.ndarray = None,
-                    x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None,
-                    y_min: float = None, y_max: float = None, cmap: Union[str, Colormap] = 'RdBu', cbar: bool = True,
-                    cbar_kws: dict = {}, cbar_ax: Axes = None, ax: Axes = None, backend: str = None, **kwargs) -> Axes:
+                    z: str = None, kernel: BaseKernel = None, rotation: np.ndarray = None,
+                    rot_origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None, x_min: float = None,
+                    x_max: float = None, y_min: float = None, y_max: float = None, cmap: Union[str, Colormap] = 'RdBu',
+                    cbar: bool = True, cbar_kws: dict = {}, cbar_ax: Axes = None, ax: Axes = None, backend: str = None,
+                    **kwargs) -> Axes:
     """ Render 3D particle data to a 2D grid, using a 3D cross-section.
 
     Render the data within a SarracenDataFrame to a 2D matplotlib object, using a 3D -> 2D
@@ -589,7 +590,7 @@ def render_3d_cross(data: 'SarracenDataFrame', target: str, z_slice: float = Non
     rotation: array_like or Rotation, optional
         The rotation to apply to the data before rendering. If defined as an array, the
         order of rotations is [z, y, x] in degrees.
-    origin: array_like, optional
+    rot_origin: array_like, optional
         Point of rotation of the data, in [x, y, z] form. Defaults to the centre
         point of the bounds of the data.
     x_pixels, y_pixels: int, optional
@@ -628,7 +629,7 @@ def render_3d_cross(data: 'SarracenDataFrame', target: str, z_slice: float = Non
         If `target`, `x`, `y`, `z`, mass, density, or smoothing length columns do not
         exist in `data`.
     """
-    image = interpolate_3d_cross(data, target, z_slice, x, y, z, kernel, rotation, origin, x_pixels, y_pixels, x_min,
+    image = interpolate_3d_cross(data, target, z_slice, x, y, z, kernel, rotation, rot_origin, x_pixels, y_pixels, x_min,
                                  x_max, y_min, y_max, backend)
 
     if ax is None:

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -163,42 +163,42 @@ class SarracenDataFrame(DataFrame):
 
     @_copy_doc(render_3d)
     def render_3d(self, target: str, x: str = None, y: str = None, kernel: BaseKernel = None, int_samples: int = 1000,
-                  rotation: np.ndarray = None, origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None,
-                  x_min: float = None, x_max: float = None, y_min: float = None, y_max: float = None,
-                  cmap: Union[str, Colormap] = 'RdBu', cbar: bool = True, cbar_kws: dict = {}, cbar_ax: Axes = None,
-                  ax: Axes = None, backend: str = None, **kwargs) -> Axes:
+                  rotation: np.ndarray = None, rot_origin: np.ndarray = None, x_pixels: int = None,
+                  y_pixels: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
+                  y_max: float = None, cmap: Union[str, Colormap] = 'RdBu', cbar: bool = True, cbar_kws: dict = {},
+                  cbar_ax: Axes = None, ax: Axes = None, backend: str = None, **kwargs) -> Axes:
 
-        return render_3d(self, target, x, y, kernel, int_samples, rotation, origin, x_pixels, y_pixels, x_min, x_max,
+        return render_3d(self, target, x, y, kernel, int_samples, rotation, rot_origin, x_pixels, y_pixels, x_min, x_max,
                          y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, backend, **kwargs)
 
     @_copy_doc(render_3d_cross)
     def render_3d_cross(self, target: str, z_slice: float = None, x: str = None, y: str = None, z: str = None,
-                        kernel: BaseKernel = None, rotation: np.ndarray = None, origin: np.ndarray = None,
+                        kernel: BaseKernel = None, rotation: np.ndarray = None, rot_origin: np.ndarray = None,
                         x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None,
                         y_min: float = None, y_max: float = None, cmap: Union[str, Colormap] = 'RdBu',
                         cbar: bool = True, cbar_kws: dict = {}, cbar_ax: Axes = None, ax: Axes = None,
                         backend: str = None, **kwargs) -> Axes:
 
-        return render_3d_cross(self, target, z_slice, x, y, z, kernel, rotation, origin, x_pixels, y_pixels, x_min,
+        return render_3d_cross(self, target, z_slice, x, y, z, kernel, rotation, rot_origin, x_pixels, y_pixels, x_min,
                                x_max, y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, backend, **kwargs)
 
     @_copy_doc(streamlines)
     def streamlines(self, target: Union[Tuple[str, str], Tuple[str, str, str]], z_slice: int = None, x: str = None,
                     y: str = None, z: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
-                    rotation: np.ndarray = None, origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None,
-                    x_min: float = None, x_max: float = None, y_min: float = None, y_max: float = None, ax: Axes = None,
-                    backend: str='cpu', **kwargs) -> Axes:
-        return streamlines(self, target, z_slice, x, y, z, kernel, integral_samples, rotation, origin, x_pixels,
+                    rotation: np.ndarray = None, rot_origin: np.ndarray = None, x_pixels: int = None,
+                    y_pixels: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
+                    y_max: float = None, ax: Axes = None, backend: str='cpu', **kwargs) -> Axes:
+        return streamlines(self, target, z_slice, x, y, z, kernel, integral_samples, rotation, rot_origin, x_pixels,
                            y_pixels, x_min, x_max, y_min, y_max, ax, backend, **kwargs)
 
     @_copy_doc(arrowplot)
     def arrowplot(self, target: Union[Tuple[str, str], Tuple[str, str, str]], z_slice: int = None, x: str = None,
                   y: str = None, z: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
-                  rotation: np.ndarray = None, origin: np.ndarray = None, x_arrows: int = None, y_arrows: int = None,
-                  x_min: float = None, x_max: float = None, y_min: float = None, y_max: float = None, ax: Axes = None,
-                  backend: str='cpu', **kwargs) -> Axes:
-        return arrowplot(self, target, z_slice, x, y, z, kernel, integral_samples, rotation, origin, x_arrows, y_arrows,
-                         x_min, x_max, y_min, y_max, ax, backend, **kwargs)
+                  rotation: np.ndarray = None, rot_origin: np.ndarray = None, x_arrows: int = None,
+                  y_arrows: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
+                  y_max: float = None, ax: Axes = None, backend: str='cpu', **kwargs) -> Axes:
+        return arrowplot(self, target, z_slice, x, y, z, kernel, integral_samples, rotation, rot_origin, x_arrows,
+                         y_arrows, x_min, x_max, y_min, y_max, ax, backend, **kwargs)
 
     @property
     def params(self):

--- a/sarracen/tests/test_interpolate.py
+++ b/sarracen/tests/test_interpolate.py
@@ -1041,7 +1041,7 @@ def test_required_columns(backend):
         with raises(KeyError):
             interpolate_2d_cross(sdf_dropped, 'A')
         with raises(KeyError):
-            interpolate_2d_vec(sdf_dropped, 'A')
+            interpolate_2d_vec(sdf_dropped, 'A', 'B')
 
         sdf_dropped = sdf_3.drop(column, axis=1)
         with raises(KeyError):

--- a/sarracen/tests/test_render.py
+++ b/sarracen/tests/test_render.py
@@ -1,15 +1,22 @@
 """pytest unit tests for render.py functions."""
 import pandas as pd
 from matplotlib import pyplot as plt
+from numba import cuda
 from numpy.testing import assert_array_equal
+from pytest import mark
 
 from sarracen import SarracenDataFrame, interpolate_2d, interpolate_2d_cross, interpolate_3d, interpolate_3d_cross
 from sarracen.render import render_2d, render_2d_cross, render_3d, render_3d_cross
 
+backends = ['cpu']
+if cuda.is_available():
+    backends.append('gpu')
 
-def test_interpolation_passthrough():
+@mark.parametrize("backend", backends)
+def test_interpolation_passthrough(backend):
     df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf = SarracenDataFrame(df)
+    sdf.backend = backend
 
     fig, ax = plt.subplots()
     render_2d(sdf, 'P', ax=ax)
@@ -23,6 +30,7 @@ def test_interpolation_passthrough():
 
     df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf = SarracenDataFrame(df)
+    sdf.backend = backend
 
     fig, ax = plt.subplots()
     render_3d(sdf, 'P', ax=ax)
@@ -35,9 +43,11 @@ def test_interpolation_passthrough():
     assert_array_equal(ax.images[0].get_array().filled(0), interpolate_3d_cross(sdf, 'P'))
 
 
-def test_cmap():
+@mark.parametrize("backend", backends)
+def test_cmap(backend):
     df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf = SarracenDataFrame(df)
+    sdf.backend = backend
 
     fig, ax = plt.subplots()
     render_2d(sdf, 'P', ax=ax, cmap='magma')
@@ -46,6 +56,7 @@ def test_cmap():
 
     df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf = SarracenDataFrame(df)
+    sdf.backend = backend
 
     fig, ax = plt.subplots()
     render_3d(sdf, 'P', cmap='magma', ax=ax)
@@ -58,11 +69,14 @@ def test_cmap():
     assert ax.images[0].cmap.name == 'magma'
 
 
-def test_cbar_exclusion():
+@mark.parametrize("backend", backends)
+def test_cbar_exclusion(backend):
     df_2 = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf_2 = SarracenDataFrame(df_2)
+    sdf_2.backend = backend
     df_3 = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf_3 = SarracenDataFrame(df_3)
+    sdf_3.backend = backend
 
     for func in [render_2d, render_3d, render_3d_cross]:
         fig, ax = plt.subplots()
@@ -76,11 +90,14 @@ def test_cbar_exclusion():
         assert ax.images[-1].colorbar is None
 
 
-def test_cbar_keywords():
+@mark.parametrize("backend", backends)
+def test_cbar_keywords(backend):
     df_2 = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf_2 = SarracenDataFrame(df_2)
+    sdf_2.backend = backend
     df_3 = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf_3 = SarracenDataFrame(df_3)
+    sdf_3.backend = backend
 
     for func in [render_2d, render_3d, render_3d_cross]:
         fig, ax = plt.subplots()
@@ -89,11 +106,14 @@ def test_cbar_keywords():
         assert ax.images[-1].colorbar.orientation == 'horizontal'
 
 
-def test_kwargs():
+@mark.parametrize("backend", backends)
+def test_kwargs(backend):
     df_2 = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf_2 = SarracenDataFrame(df_2)
+    sdf_2.backend = backend
     df_3 = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf_3 = SarracenDataFrame(df_3)
+    sdf_3.backend = backend
 
     for func in [render_2d, render_3d, render_3d_cross]:
         fig, ax = plt.subplots()
@@ -107,9 +127,11 @@ def test_kwargs():
     assert ax.lines[0].get_linestyle() == '--'
 
 
-def test_rotated_ticks():
+@mark.parametrize("backend", backends)
+def test_rotated_ticks(backend):
     df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf = SarracenDataFrame(df)
+    sdf.backend = backend
 
     for func in [render_3d, render_3d_cross]:
         fig, ax = plt.subplots()
@@ -119,11 +141,14 @@ def test_rotated_ticks():
         assert ax.get_yticks().size == 0
 
 
-def test_plot_labels():
+@mark.parametrize("backend", backends)
+def test_plot_labels(backend):
     df_2 = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf_2 = SarracenDataFrame(df_2)
+    sdf_2.backend = backend
     df_3 = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf_3 = SarracenDataFrame(df_3)
+    sdf_3.backend = backend
 
     for func in [render_2d, render_3d, render_3d_cross]:
         fig, ax = plt.subplots()
@@ -153,11 +178,14 @@ def test_plot_labels():
     assert ax.get_ylabel() == 'rho'
 
 
-def test_plot_bounds():
+@mark.parametrize("backend", backends)
+def test_plot_bounds(backend):
     df_2 = pd.DataFrame({'x': [6, 3], 'y': [5, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf_2 = SarracenDataFrame(df_2)
+    sdf_2.backend = backend
     df_3 = pd.DataFrame({'x': [6, 3], 'y': [5, 1], 'z': [0, 0], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf_3 = SarracenDataFrame(df_3)
+    sdf_3.backend = backend
 
     for func in [render_2d, render_2d_cross, render_3d, render_3d_cross]:
         fig, ax = plt.subplots()
@@ -182,7 +210,8 @@ def test_plot_bounds():
             assert ax.figure.axes[1].get_ylim() == (0, interpolate_3d_cross(sdf_3, 'P').max())
 
 
-def test_snap():
+@mark.parametrize("backend", backends)
+def test_snap(backend):
     df = pd.DataFrame({'x': [0.0001, 5.2],
                        'y': [3.00004, 0.1],
                        'P': [1, 1],
@@ -190,6 +219,7 @@ def test_snap():
                        'rho': [1, 1],
                        'm': [1, 1]})
     sdf = SarracenDataFrame(df)
+    sdf.backend = backend
 
     fig, ax = plt.subplots()
     sdf.render_2d('P', ax=ax)

--- a/sarracen/tests/test_render.py
+++ b/sarracen/tests/test_render.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_array_equal
 from pytest import mark
 
 from sarracen import SarracenDataFrame, interpolate_2d, interpolate_2d_cross, interpolate_3d, interpolate_3d_cross
-from sarracen.render import render_2d, render_2d_cross, render_3d, render_3d_cross
+from sarracen.render import render_2d, render_2d_cross, render_3d, render_3d_cross, streamlines
 
 backends = ['cpu']
 if cuda.is_available():
@@ -14,18 +14,17 @@ if cuda.is_available():
 
 @mark.parametrize("backend", backends)
 def test_interpolation_passthrough(backend):
-    df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
+    df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'P': [1, 1], 'Ax': [3, 2], 'Ay': [2, 1], 'h': [1, 1], 'rho': [1, 1],
+                       'm': [1, 1]})
     sdf = SarracenDataFrame(df)
     sdf.backend = backend
 
     fig, ax = plt.subplots()
     render_2d(sdf, 'P', ax=ax)
-
     assert_array_equal(ax.images[0].get_array().filled(0), interpolate_2d(sdf, 'P'))
 
     fig, ax = plt.subplots()
     render_2d_cross(sdf, 'P', x1=3, x2=6, y1=5, y2=1, ax=ax)
-
     assert_array_equal(ax.lines[0].get_ydata(), interpolate_2d_cross(sdf, 'P', x1=3, x2=6, y1=5, y2=1))
 
     df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
@@ -34,12 +33,10 @@ def test_interpolation_passthrough(backend):
 
     fig, ax = plt.subplots()
     render_3d(sdf, 'P', ax=ax)
-
     assert_array_equal(ax.images[0].get_array().filled(0), interpolate_3d(sdf, 'P'))
 
     fig, ax = plt.subplots()
     render_3d_cross(sdf, 'P', ax=ax)
-
     assert_array_equal(ax.images[0].get_array().filled(0), interpolate_3d_cross(sdf, 'P'))
 
 

--- a/sarracen/tests/test_render.py
+++ b/sarracen/tests/test_render.py
@@ -1,181 +1,185 @@
 """pytest unit tests for render.py functions."""
 import pandas as pd
-import numpy as np
 from matplotlib import pyplot as plt
-from matplotlib.axes import Axes
-from pytest import approx
+from numpy.testing import assert_array_equal
 
-from sarracen import SarracenDataFrame
-from sarracen.kernels import CubicSplineKernel
-from sarracen.render import render_2d, render_2d_cross, render_3d, render_3d_cross, streamlines, arrowplot
+from sarracen import SarracenDataFrame, interpolate_2d, interpolate_2d_cross, interpolate_3d, interpolate_3d_cross
+from sarracen.render import render_2d, render_2d_cross, render_3d, render_3d_cross
 
 
-def test_2d_plot():
-    df = pd.DataFrame({'x': [3, 6],
-                       'y': [5, 1],
-                       'P': [1, 1],
-                       'h': [1, 1],
-                       'rho': [1, 1],
-                       'm': [1, 1]})
-    sdf = SarracenDataFrame(df)
-
-    fig, ax = plt.subplots()
-    sdf.render_2d('P', ax=ax)
-
-    assert isinstance(ax, Axes)
-
-    assert ax.get_xlabel() == 'x'
-    assert ax.get_ylabel() == 'y'
-    # the colorbar is contained in a second axes object inside the figure
-    assert ax.figure.axes[1].get_ylabel() == 'P'
-
-    assert ax.get_xlim() == (3, 6)
-    assert ax.get_ylim() == (1, 5)
-
-    # aspect ratio of data max & min is 4/3,
-    # pixel count => (512, 683)
-    # pixel width => (3/512, 4/638)
-    # both particles are in corners
-    # therefore closest pixel is => sqrt((3/1024)**2, (2/683)**2)
-    # use default kernel to determine the max pressure value
-    assert ax.figure.axes[1].get_ylim() == (0, CubicSplineKernel().w(np.sqrt((3 / 1024) ** 2 + (2 / 683) ** 2), 2))
-
-
-def test_2d_cross_plot():
-    df = pd.DataFrame({'rx': [0, 5],
-                       'P': [1, 1],
-                       'h': [1, 1],
-                       'rho': [1, 1],
-                       'y': [0, 4],
-                       'm': [1, 1]})
-    sdf = SarracenDataFrame(df)
-
-    fig, ax = plt.subplots()
-    sdf.render_2d_cross('P', ax=ax)
-
-    assert isinstance(ax, Axes)
-
-    assert ax.get_xlabel() == 'cross-section (rx, y)'
-    assert ax.get_ylabel() == 'P'
-
-    # cross section from (0, 0) -> (5, 4), therefore x goes from 0 -> sqrt(5**2 + 4**2)
-    assert ax.get_xlim() == (0, np.sqrt(41))
-    # 512 pixels across (by default), and both particles are in corners
-    # therefore closest pixel to a particle is sqrt(41)/1024 units away
-    # use default kernel to determine the max pressure value
-    assert ax.get_ylim() == (0, approx(CubicSplineKernel().w(np.sqrt(41) / 1024, 2)))
-
-
-def test_3d_plot():
-    df = pd.DataFrame({'rx': [0, 5],
-                       'P': [1, 1],
-                       'h': [1, 1],
-                       'rz': [3, 1],
-                       'rho': [1, 1],
-                       'y': [0, 4],
-                       'm': [1, 1]})
-    sdf = SarracenDataFrame(df)
-
-    fig, ax = plt.subplots()
-    sdf.render_3d('P', int_samples=10000, x_pixels=300, ax=ax)
-
-    assert isinstance(ax, Axes)
-
-    assert ax.get_xlabel() == 'rx'
-    assert ax.get_ylabel() == 'y'
-    # the colorbar is contained in a second axes object inside the figure
-    assert ax.figure.axes[1].get_ylabel() == 'column P'
-
-    assert ax.get_xlim() == (0, 5)
-    assert ax.get_ylim() == (0, 4)
-    # particle width is 1/60
-    # therefore closest pixel has q=sqrt(2*(1/120)^2)
-    # F(q) ~= 0.477372919027 (calculated externally)
-    assert ax.figure.axes[1].get_ylim() == (0, approx(0.477372919027))
-
-
-def test_3d_cross_plot():
-    df = pd.DataFrame({'rx': [0, 2.5, 5],
-                       'P': [1, 1, 1],
-                       'h': [1, 1, 1],
-                       'rz': [3, 2, 1],
-                       'rho': [1, 1, 1],
-                       'y': [0, 2, 4],
-                       'm': [1, 1, 1]})
-    sdf = SarracenDataFrame(df)
-
-    # setting the pixel count to an odd number ensures that the middle particle at (2.5, 2, 2) is at the
-    # exact same position as the centre pixel.
-    fig, ax = plt.subplots()
-    sdf.render_3d_cross('P', x_pixels=489, ax=ax)
-
-    assert isinstance(ax, Axes)
-
-    assert ax.get_xlabel() == 'rx'
-    assert ax.get_ylabel() == 'y'
-    # the colorbar is contained in a second axes object inside the figure
-    assert ax.figure.axes[1].get_ylabel() == 'P'
-
-    assert ax.get_xlim() == (0, 5)
-    assert ax.get_ylim() == (0, 4)
-
-    # closest pixel/particle pair comes from the particle at (2.5, 2, 2), with r = 0.
-    assert ax.figure.axes[1].get_ylim() == (0, approx(CubicSplineKernel().w(0, 3)))
-
-
-def test_render_passthrough():
-    # Basic tests that both sdf.render() and render(sdf) return the same plots
-
-    # 2D dataset
+def test_interpolation_passthrough():
     df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf = SarracenDataFrame(df)
 
-    fig1, ax1 = plt.subplots()
-    fig2, ax2 = plt.subplots()
-    ax1 = sdf.render_2d('P', ax=ax1)
-    ax2 = render_2d(sdf, 'P', ax=ax2)
+    fig, ax = plt.subplots()
+    render_2d(sdf, 'P', ax=ax)
 
-    assert repr(ax1) == repr(ax2)
+    assert_array_equal(ax.images[0].get_array().filled(0), interpolate_2d(sdf, 'P'))
 
-    fig1, ax1 = plt.subplots()
-    fig2, ax2 = plt.subplots()
-    ax1 = sdf.render_2d_cross('P', ax=ax1)
-    ax2 = render_2d_cross(sdf, 'P', ax=ax2)
+    fig, ax = plt.subplots()
+    render_2d_cross(sdf, 'P', x1=3, x2=6, y1=5, y2=1, ax=ax)
 
-    assert repr(ax1) == repr(ax2)
+    assert_array_equal(ax.lines[0].get_ydata(), interpolate_2d_cross(sdf, 'P', x1=3, x2=6, y1=5, y2=1))
 
-    # 3D dataset
-    df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'Ax': [5, 3], 'Ay': [2, 3],
-                       'Az': [1, -1], 'rho': [1, 1], 'm': [1, 1]})
+    df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf = SarracenDataFrame(df)
 
-    fig1, ax1 = plt.subplots()
-    fig2, ax2 = plt.subplots()
-    ax1 = sdf.render_3d('P', ax=ax1)
-    ax2 = render_3d(sdf, 'P', ax=ax2)
+    fig, ax = plt.subplots()
+    render_3d(sdf, 'P', ax=ax)
 
-    assert repr(ax1) == repr(ax2)
+    assert_array_equal(ax.images[0].get_array().filled(0), interpolate_3d(sdf, 'P'))
 
-    fig1, ax1 = plt.subplots()
-    fig2, ax2 = plt.subplots()
-    ax1 = sdf.render_3d_cross('P', ax=ax1)
-    ax2 = render_3d_cross(sdf, 'P', ax=ax2)
+    fig, ax = plt.subplots()
+    render_3d_cross(sdf, 'P', ax=ax)
 
-    assert repr(ax1) == repr(ax2)
+    assert_array_equal(ax.images[0].get_array().filled(0), interpolate_3d_cross(sdf, 'P'))
 
-    fig1, ax1 = plt.subplots()
-    fig2, ax2 = plt.subplots()
-    ax1 = sdf.streamlines(('Ax', 'Ay', 'Az'), ax=ax1)
-    ax2 = streamlines(sdf, ('Ax', 'Ay', 'Az'), ax=ax2)
 
-    assert repr(ax1) == repr(ax2)
+def test_cmap():
+    df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
+    sdf = SarracenDataFrame(df)
 
-    fig1, ax1 = plt.subplots()
-    fig2, ax2 = plt.subplots()
-    ax1 = sdf.arrowplot(('Ax', 'Ay', 'Az'), ax=ax1)
-    ax2 = arrowplot(sdf, ('Ax', 'Ay', 'Az'), ax=ax2)
+    fig, ax = plt.subplots()
+    render_2d(sdf, 'P', ax=ax, cmap='magma')
 
-    assert repr(ax1) == repr(ax2)
+    assert ax.images[0].cmap.name == 'magma'
+
+    df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
+    sdf = SarracenDataFrame(df)
+
+    fig, ax = plt.subplots()
+    render_3d(sdf, 'P', cmap='magma', ax=ax)
+
+    assert ax.images[0].cmap.name == 'magma'
+
+    fig, ax = plt.subplots()
+    render_3d_cross(sdf, 'P', cmap='magma', ax=ax)
+
+    assert ax.images[0].cmap.name == 'magma'
+
+
+def test_cbar_exclusion():
+    df_2 = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
+    sdf_2 = SarracenDataFrame(df_2)
+    df_3 = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
+    sdf_3 = SarracenDataFrame(df_3)
+
+    for func in [render_2d, render_3d, render_3d_cross]:
+        fig, ax = plt.subplots()
+        func(sdf_2 if func is render_2d else sdf_3, 'P', ax=ax, cbar=True)
+
+        assert ax.images[-1].colorbar is not None
+
+        fig, ax = plt.subplots()
+        func(sdf_2 if func is render_2d else sdf_3, 'P', ax=ax, cbar=False)
+
+        assert ax.images[-1].colorbar is None
+
+
+def test_cbar_keywords():
+    df_2 = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
+    sdf_2 = SarracenDataFrame(df_2)
+    df_3 = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
+    sdf_3 = SarracenDataFrame(df_3)
+
+    for func in [render_2d, render_3d, render_3d_cross]:
+        fig, ax = plt.subplots()
+        func(sdf_2 if func is render_2d else sdf_3, 'P', ax=ax, cbar_kws={'orientation': 'horizontal'})
+
+        assert ax.images[-1].colorbar.orientation == 'horizontal'
+
+
+def test_kwargs():
+    df_2 = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
+    sdf_2 = SarracenDataFrame(df_2)
+    df_3 = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
+    sdf_3 = SarracenDataFrame(df_3)
+
+    for func in [render_2d, render_3d, render_3d_cross]:
+        fig, ax = plt.subplots()
+        func(sdf_2 if func is render_2d else sdf_3, 'P', ax=ax, origin='upper')
+
+        assert ax.images[0].origin == 'upper'
+
+    fig, ax = plt.subplots()
+    render_2d_cross(sdf_2, 'P', x1=3, x2=6, y1=5, y2=1, ax=ax, linestyle='--')
+
+    assert ax.lines[0].get_linestyle() == '--'
+
+
+def test_rotated_ticks():
+    df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
+    sdf = SarracenDataFrame(df)
+
+    for func in [render_3d, render_3d_cross]:
+        fig, ax = plt.subplots()
+        func(sdf, 'P', rotation=[34, 23, 50], ax=ax)
+
+        assert ax.get_xticks().size == 0
+        assert ax.get_yticks().size == 0
+
+
+def test_plot_labels():
+    df_2 = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
+    sdf_2 = SarracenDataFrame(df_2)
+    df_3 = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
+    sdf_3 = SarracenDataFrame(df_3)
+
+    for func in [render_2d, render_3d, render_3d_cross]:
+        fig, ax = plt.subplots()
+        func(sdf_2 if func is render_2d else sdf_3, 'P', ax=ax)
+
+        assert ax.get_xlabel() == 'x'
+        assert ax.get_ylabel() == 'y'
+        assert ax.figure.axes[1].get_ylabel() == ('column ' if func is render_3d else '') + 'P'
+
+        fig, ax = plt.subplots()
+        func(sdf_2 if func is render_2d else sdf_3, 'rho', x='y', y='x', ax=ax)
+
+        assert ax.get_xlabel() == 'y'
+        assert ax.get_ylabel() == 'x'
+        assert ax.figure.axes[1].get_ylabel() == ('column ' if func is render_3d else '') + 'rho'
+
+    fig, ax = plt.subplots()
+    render_2d_cross(sdf_2, 'P', ax=ax)
+
+    assert ax.get_xlabel() == 'cross-section (x, y)'
+    assert ax.get_ylabel() == 'P'
+
+    fig, ax = plt.subplots()
+    render_2d_cross(sdf_2, 'rho', x='y', y='x', ax=ax)
+
+    assert ax.get_xlabel() == 'cross-section (y, x)'
+    assert ax.get_ylabel() == 'rho'
+
+
+def test_plot_bounds():
+    df_2 = pd.DataFrame({'x': [6, 3], 'y': [5, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
+    sdf_2 = SarracenDataFrame(df_2)
+    df_3 = pd.DataFrame({'x': [6, 3], 'y': [5, 1], 'z': [0, 0], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
+    sdf_3 = SarracenDataFrame(df_3)
+
+    for func in [render_2d, render_2d_cross, render_3d, render_3d_cross]:
+        fig, ax = plt.subplots()
+        func(sdf_2 if func is render_2d or func is render_2d_cross else sdf_3, 'P', ax=ax)
+
+        if func is render_2d_cross:
+            assert ax.get_xlim() == (0, 5)
+
+            # 512 pixels across (by default), and both particles are in corners
+            # therefore closest pixel to a particle is sqrt(41)/1024 units away
+            # use default kernel to determine the max pressure value
+            assert ax.get_ylim() == (0, interpolate_2d_cross(sdf_2, 'P').max())
+        else:
+            assert ax.get_xlim() == (3, 6)
+            assert ax.get_ylim() == (1, 5)
+
+        if func is render_2d:
+            assert ax.figure.axes[1].get_ylim() == (0, interpolate_2d(sdf_2, 'P').max())
+        elif func is render_3d:
+            assert ax.figure.axes[1].get_ylim() == (0, interpolate_3d(sdf_3, 'P').max())
+        elif func is render_3d_cross:
+            assert ax.figure.axes[1].get_ylim() == (0, interpolate_3d_cross(sdf_3, 'P').max())
 
 
 def test_snap():

--- a/sarracen/tests/test_sarracen_dataframe.py
+++ b/sarracen/tests/test_sarracen_dataframe.py
@@ -1,18 +1,14 @@
 """pytest unit tests for sarracen_dataframe.py functionality."""
 import pandas as pd
+from matplotlib import pyplot as plt
 
-from sarracen import SarracenDataFrame
+from sarracen import SarracenDataFrame, render_2d, render_2d_cross, render_3d, render_3d_cross
 
 
 def test_special_columns():
     # The 'x', 'y', 'rho', 'm', and 'h' keywords should be detected.
     # A 'z' column should not be detected.
-    df = pd.DataFrame({'P': [1, 1],
-                       'h': [1, 1],
-                       'rho': [1, 1],
-                       'x': [5, 6],
-                       'y': [5, 4],
-                       'm': [1, 1]})
+    df = pd.DataFrame({'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'x': [5, 6], 'y': [5, 4], 'm': [1, 1]})
     sdf = SarracenDataFrame(df)
 
     assert sdf.xcol == 'x'
@@ -24,12 +20,7 @@ def test_special_columns():
 
     # The 'rx', 'ry', 'rz', 'density', and 'mass' keywords should be detected.
     # An 'h' column should not be detected.
-    df = pd.DataFrame({'ry': [-1, 1],
-                       'density': [1, 1],
-                       'rx': [3, 4],
-                       'P': [1, 1],
-                       'rz': [4, 3],
-                       'mass': [1, 1]})
+    df = pd.DataFrame({'ry': [-1, 1], 'density': [1, 1], 'rx': [3, 4], 'P': [1, 1], 'rz': [4, 3], 'mass': [1, 1]})
     sdf = SarracenDataFrame(df)
 
     assert sdf.xcol == 'rx'
@@ -42,11 +33,7 @@ def test_special_columns():
     # No keywords, so fall back to the first two columns for x and y.
     # Even though 'k' exists, this will be assumed to be 2D data.
     # The 'h' column will be detected, but no density or mass column will be detected.
-    df = pd.DataFrame({'i': [3.4, 2.1],
-                       'j': [4.9, 1.6],
-                       'k': [2.3, 2.0],
-                       'h': [1, 1],
-                       'P': [1, 1]})
+    df = pd.DataFrame({'i': [3.4, 2.1], 'j': [4.9, 1.6], 'k': [2.3, 2.0], 'h': [1, 1], 'P': [1, 1]})
     sdf = SarracenDataFrame(df)
 
     assert sdf.xcol == 'i'
@@ -59,48 +46,26 @@ def test_special_columns():
 
 def test_dimensions():
     # This should be detected as 3-dimensional data.
-    df = pd.DataFrame({'P': [1, 1],
-                       'z': [4, 3],
-                       'h': [1, 1],
-                       'rho': [1, 1],
-                       'x': [5, 6],
-                       'y': [5, 4],
-                       'm': [1, 1]})
+    df = pd.DataFrame({'P': [1, 1], 'z': [4, 3], 'h': [1, 1], 'rho': [1, 1], 'x': [5, 6], 'y': [5, 4], 'm': [1, 1]})
     sdf = SarracenDataFrame(df)
 
     assert sdf.get_dim() == 3
 
     # This should be detected as 2-dimensional data.
-    df = pd.DataFrame({'P': [1, 1],
-                       'h': [1, 1],
-                       'y': [5, 4],
-                       'rho': [1, 1],
-                       'm': [1, 1],
-                       'x': [5, 6]})
+    df = pd.DataFrame({'P': [1, 1], 'h': [1, 1], 'y': [5, 4], 'rho': [1, 1], 'm': [1, 1], 'x': [5, 6]})
     sdf = SarracenDataFrame(df)
 
     assert sdf.get_dim() == 2
 
     # This should assumed to be 2-dimensional data.
-    df = pd.DataFrame({'P': [1, 1],
-                       'h': [1, 1],
-                       'rho': [1, 1],
-                       'm': [1, 1]})
+    df = pd.DataFrame({'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf = SarracenDataFrame(df)
 
     assert sdf.get_dim() == 2
 
 
 def test_column_changing():
-    df = pd.DataFrame({'P': [1],
-                       'z': [2],
-                       'h': [3],
-                       'rho': [4],
-                       'x': [5],
-                       'y': [6],
-                       'm': [7],
-                       'd': [8],
-                       'smooth': [9],
+    df = pd.DataFrame({'P': [1], 'z': [2], 'h': [3], 'rho': [4], 'x': [5], 'y': [6], 'm': [7], 'd': [8], 'smooth': [9],
                        'ma': [10]})
     sdf = SarracenDataFrame(df)
 
@@ -138,3 +103,44 @@ def test_column_changing():
     assert sdf.rhocol == 'd'
     assert sdf.mcol == 'ma'
     assert sdf.hcol == 'smooth'
+
+
+def test_render_passthrough():
+    # Basic tests that both sdf.render() and render(sdf) return the same plots
+
+    # 2D dataset
+    df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
+    sdf = SarracenDataFrame(df)
+
+    fig1, ax1 = plt.subplots()
+    fig2, ax2 = plt.subplots()
+    ax1 = sdf.render_2d('P', ax=ax1)
+    ax2 = render_2d(sdf, 'P', ax=ax2)
+
+    assert repr(ax1) == repr(ax2)
+
+    fig1, ax1 = plt.subplots()
+    fig2, ax2 = plt.subplots()
+    ax1 = sdf.render_2d_cross('P', ax=ax1)
+    ax2 = render_2d_cross(sdf, 'P', ax=ax2)
+
+    assert repr(ax1) == repr(ax2)
+
+    # 3D dataset
+    df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'Ax': [5, 3], 'Ay': [2, 3],
+                       'Az': [1, -1], 'rho': [1, 1], 'm': [1, 1]})
+    sdf = SarracenDataFrame(df)
+
+    fig1, ax1 = plt.subplots()
+    fig2, ax2 = plt.subplots()
+    ax1 = sdf.render_3d('P', ax=ax1)
+    ax2 = render_3d(sdf, 'P', ax=ax2)
+
+    assert repr(ax1) == repr(ax2)
+
+    fig1, ax1 = plt.subplots()
+    fig2, ax2 = plt.subplots()
+    ax1 = sdf.render_3d_cross('P', ax=ax1)
+    ax2 = render_3d_cross(sdf, 'P', ax=ax2)
+
+    assert repr(ax1) == repr(ax2)


### PR DESCRIPTION
Rewrite of the unit tests for interpolation functions, render functions, and kernels. The total number of unit tests has been greatly expanded, from 22 to 73. The depth of testing has been greatly expanded, to include in-depth tests of rotations, vector functions, and more. As well, all interpolation and rendering tests are performed on both CPU and GPU backends (the GPU tests will only run if a CUDA supported device is detected).

In this new suite, a few of the tests are currently expected to fail, and highlight issues that should be fixed in the future:

- `test_single_repeated_particle` will fail on the CPU backend, highlighting a race condition in the CPU interpolation functions.
- Some other tests involving interpolation of two particles (`test_axes_rotation_equivalency` for example) will occasionally fail on the CPU backend, due to the same race condition.
- `test_2d_xsec_equivalency` will fail on both backends, since a vertical 2D cross-section does not work as intended.
- `test_required_columns` will fail on both backends, since dropping a column from a SarracenDataFrame returns a regular DataFrame.