### PR TITLE
SarracenDataFrame slicing bugfix

### DIFF
--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -63,6 +63,10 @@ class SarracenDataFrame(DataFrame):
         self._kernel = CubicSplineKernel()
         self._backend = 'cpu'
 
+    @property
+    def _constructor(self):
+        return SarracenDataFrame
+
     def _identify_special_columns(self):
         """ Identify special columns commonly used in analysis functions.
 


### PR DESCRIPTION
Adds an `_constructor` private method to SarracenDataFrame. This ensures that when a SarracenDataFrame is sliced or manipulated in a way that doesn't return a Series, a SarracenDataFrame is returned instead.

With this fix, particle data can now be manipulated by the user before plotting, without losing any vital information.