### PR TITLE
Exact 2D & 3D projective interpolation

### DIFF
--- a/sarracen/interpolate/base_backend.py
+++ b/sarracen/interpolate/base_backend.py
@@ -30,9 +30,10 @@ class BaseBackend:
         return zeros(pixels)
 
     @staticmethod
-    def interpolate_3d_projection(target: ndarray, x: ndarray, y: ndarray, mass: ndarray, rho: ndarray, h: ndarray,
-                                  weight_function: CPUDispatcher, kernel_radius: float, x_pixels: int, y_pixels: int,
-                                  x_min: float, x_max: float, y_min: float, y_max: float) -> ndarray:
+    def interpolate_3d_projection(target: ndarray, x: ndarray, y: ndarray, z: ndarray, mass: ndarray, rho: ndarray,
+                                  h: ndarray, weight_function: CPUDispatcher, kernel_radius: float, x_pixels: int,
+                                  y_pixels: int, x_min: float, x_max: float, y_min: float, y_max: float,
+                                  exact: bool) -> ndarray:
         """ Interpolate 3D particle data to a 2D grid of pixels. """
         return zeros((y_pixels, x_pixels))
 

--- a/sarracen/interpolate/base_backend.py
+++ b/sarracen/interpolate/base_backend.py
@@ -18,7 +18,7 @@ class BaseBackend:
     def interpolate_2d_render_vec(target_x: ndarray, target_y: ndarray, x: ndarray, y: ndarray, mass: ndarray,
                                   rho: ndarray, h: ndarray, weight_function: CPUDispatcher, kernel_radius: float,
                                   x_pixels: int, y_pixels: int, x_min: float, x_max: float, y_min: float,
-                                  y_max: float) -> Tuple[ndarray, ndarray]:
+                                  y_max: float, exact: bool) -> Tuple[ndarray, ndarray]:
         """ Interpolate 2D particle vector data to a pair of 2D grids of pixels. """
         return zeros((y_pixels, x_pixels)), zeros((y_pixels, x_pixels))
 
@@ -34,14 +34,15 @@ class BaseBackend:
                                   h: ndarray, weight_function: CPUDispatcher, kernel_radius: float, x_pixels: int,
                                   y_pixels: int, x_min: float, x_max: float, y_min: float, y_max: float,
                                   exact: bool) -> ndarray:
-        """ Interpolate 3D particle data to a 2D grid of pixels. """
+        """ Interpolate 3D particle data to a 2D grid of pixels, using column projection."""
         return zeros((y_pixels, x_pixels))
 
     @staticmethod
     def interpolate_3d_projection_vec(target_x: ndarray, target_y: ndarray, x: ndarray, y: ndarray, mass: ndarray,
                                       rho: ndarray, h: ndarray, weight_function: CPUDispatcher, kernel_radius: float,
                                       x_pixels: int, y_pixels: int, x_min: float, x_max: float, y_min: float,
-                                      y_max: float) -> Tuple[ndarray, ndarray]:
+                                      y_max: float, exact: bool) -> Tuple[ndarray, ndarray]:
+        """ Interpolate 3D particle vector data to a pair of 2D grids of pixels, using column projection."""
         return zeros((y_pixels, x_pixels)), zeros((y_pixels, x_pixels))
 
 
@@ -50,6 +51,9 @@ class BaseBackend:
                              rho: ndarray, h: ndarray, weight_function: CPUDispatcher, kernel_radius: float,
                              x_pixels: int, y_pixels: int, x_min: float, x_max: float, y_min: float,
                              y_max: float) -> ndarray:
+        """
+        Interpolate 3D particle data to a pair of 2D grids of pixels, using a 3D cross-section at a specific z value.
+        """
         return zeros((y_pixels, x_pixels))
 
 
@@ -58,4 +62,8 @@ class BaseBackend:
                                  z: ndarray, mass: ndarray, rho: ndarray, h: ndarray, weight_function: CPUDispatcher,
                                  kernel_radius: float, x_pixels: int, y_pixels: int, x_min: float, x_max: float,
                                  y_min: float, y_max: float) -> Tuple[ndarray, ndarray]:
+        """
+        Interpolate 3D particle vector data to a pair of 2D grids of pixels, using a 3D cross-section at a
+        specific z value.
+        """
         return zeros((y_pixels, x_pixels)), zeros((y_pixels, x_pixels))

--- a/sarracen/interpolate/base_backend.py
+++ b/sarracen/interpolate/base_backend.py
@@ -10,8 +10,8 @@ class BaseBackend:
     @staticmethod
     def interpolate_2d_render(target: ndarray, x: ndarray, y: ndarray, mass: ndarray, rho: ndarray, h: ndarray,
                               weight_function: CPUDispatcher, kernel_radius: float, x_pixels: int, y_pixels: int,
-                              x_min: float, x_max: float, y_min: float, y_max: float) -> ndarray:
-        """ Interpolate 2D particle data to a 2D grid of pixels. """
+                              x_min: float, x_max: float, y_min: float, y_max: float, exact: bool) -> ndarray:
+        """ Interpolate 2D particle data to a 2D grid of pixels."""
         return zeros((y_pixels, x_pixels))
 
     @staticmethod

--- a/sarracen/interpolate/cpu_backend.py
+++ b/sarracen/interpolate/cpu_backend.py
@@ -388,8 +388,8 @@ class CPUBackend(BaseBackend):
                         if q2 < 4 + 3 * pixwidthx * pixwidthy / h_data[i] ** 2:
                             pixint = 2 * wallint(0.5 * pixwidthz, x_data[i], y_data[i], xpix, ypix, pixwidthx, pixwidthy, h_data[i])
 
-                            pixint += wallint(ypix - y_data[i] + 0.5 * pixwidthy, x_data[i], z_data[i], xpix, 0, pixwidthx, pixwidthz, h_data[i])
-                            pixint += wallint(y_data[i] - ypix + 0.5 * pixwidthy, x_data[i], z_data[i], xpix, 0, pixwidthx, pixwidthz, h_data[i])
+                            pixint += wallint(ypix - y_data[i] + 0.5 * pixwidthy, x_data[i], 0, xpix, 0, pixwidthx, pixwidthz, h_data[i])
+                            pixint += wallint(y_data[i] - ypix + 0.5 * pixwidthy, x_data[i], 0, xpix, 0, pixwidthx, pixwidthz, h_data[i])
 
                             pixint += wallint(xpix - x_data[i] + 0.5 * pixwidthx, 0, y_data[i], 0, ypix, pixwidthz, pixwidthy, h_data[i])
                             pixint += wallint(x_data[i] - xpix + 0.5 * pixwidthx, 0, y_data[i], 0, ypix, pixwidthz, pixwidthy, h_data[i])

--- a/sarracen/interpolate/cpu_backend.py
+++ b/sarracen/interpolate/cpu_backend.py
@@ -6,7 +6,7 @@ from numpy import ndarray
 import numpy as np
 
 from sarracen.interpolate.base_backend import BaseBackend
-from sarracen.kernels.cubic_spline_exact import pint, wallint
+from sarracen.kernels.cubic_spline_exact import line_int, surface_int
 
 
 class CPUBackend(BaseBackend):
@@ -210,7 +210,7 @@ class CPUBackend(BaseBackend):
                         r0 = 0.5 * pixwidthy - dy
                         d1 = 0.5 * pixwidthx + dx
                         d2 = 0.5 * pixwidthx - dx
-                        pixint = pint(r0, d1, d2, h_data[i])
+                        pixint = line_int(r0, d1, d2, h_data[i])
                         wab = pixint * denom
 
                         output_local[thread, jpixmin, ipix] += term[i] * wab
@@ -227,7 +227,7 @@ class CPUBackend(BaseBackend):
                         r0 = 0.5 * pixwidthx - dx
                         d1 = 0.5 * pixwidthy - dy
                         d2 = 0.5 * pixwidthy + dy
-                        pixint = pint(r0, d1, d2, h_data[i])
+                        pixint = line_int(r0, d1, d2, h_data[i])
                         wab = pixint * denom
 
                         output_local[thread, jpix, ipixmin] += term[i] * wab
@@ -244,7 +244,7 @@ class CPUBackend(BaseBackend):
                         r0 = 0.5 * pixwidthy + dy
                         d1 = 0.5 * pixwidthx - dx
                         d2 = 0.5 * pixwidthx + dx
-                        pixint = pint(r0, d1, d2, h_data[i])
+                        pixint = line_int(r0, d1, d2, h_data[i])
                         wab = pixint * denom
 
                         output_local[thread, jpix, ipix] += term[i] * wab
@@ -258,7 +258,7 @@ class CPUBackend(BaseBackend):
                         r0 = 0.5 * pixwidthx + dx
                         d1 = 0.5 * pixwidthy + dy
                         d2 = 0.5 * pixwidthy - dy
-                        pixint = pint(r0, d1, d2, h_data[i])
+                        pixint = line_int(r0, d1, d2, h_data[i])
                         wab = pixint * denom
 
                         output_local[thread, jpix, ipix] += term[i] * wab
@@ -410,20 +410,20 @@ class CPUBackend(BaseBackend):
                             # surface integrals of each surface of the cube.
 
                             # x-y surfaces
-                            pixint = 2 * wallint(0.5 * pixwidthz, x_data[i], y_data[i], xpix, ypix, pixwidthx,
-                                                 pixwidthy, h_data[i])
+                            pixint = 2 * surface_int(0.5 * pixwidthz, x_data[i], y_data[i], xpix, ypix, pixwidthx,
+                                                     pixwidthy, h_data[i])
 
                             # x-z surfaces
-                            pixint += wallint(ypix - y_data[i] + 0.5 * pixwidthy, x_data[i], 0, xpix, 0, pixwidthx,
-                                              pixwidthz, h_data[i])
-                            pixint += wallint(y_data[i] - ypix + 0.5 * pixwidthy, x_data[i], 0, xpix, 0, pixwidthx,
-                                              pixwidthz, h_data[i])
+                            pixint += surface_int(ypix - y_data[i] + 0.5 * pixwidthy, x_data[i], 0, xpix, 0, pixwidthx,
+                                                  pixwidthz, h_data[i])
+                            pixint += surface_int(y_data[i] - ypix + 0.5 * pixwidthy, x_data[i], 0, xpix, 0, pixwidthx,
+                                                  pixwidthz, h_data[i])
 
                             # y-z surfaces
-                            pixint += wallint(xpix - x_data[i] + 0.5 * pixwidthx, 0, y_data[i], 0, ypix, pixwidthz,
-                                              pixwidthy, h_data[i])
-                            pixint += wallint(x_data[i] - xpix + 0.5 * pixwidthx, 0, y_data[i], 0, ypix, pixwidthz,
-                                              pixwidthy, h_data[i])
+                            pixint += surface_int(xpix - x_data[i] + 0.5 * pixwidthx, 0, y_data[i], 0, ypix, pixwidthz,
+                                                  pixwidthy, h_data[i])
+                            pixint += surface_int(x_data[i] - xpix + 0.5 * pixwidthx, 0, y_data[i], 0, ypix, pixwidthz,
+                                                  pixwidthy, h_data[i])
 
                             wab = pixint * dfac[i]
 

--- a/sarracen/interpolate/gpu_backend.py
+++ b/sarracen/interpolate/gpu_backend.py
@@ -14,7 +14,7 @@ class GPUBackend(BaseBackend):
     @staticmethod
     def interpolate_2d_render(target: ndarray, x: ndarray, y: ndarray, mass: ndarray, rho: ndarray, h: ndarray,
                               weight_function: CPUDispatcher, kernel_radius: float, x_pixels: int, y_pixels: int,
-                              x_min: float, x_max: float, y_min: float, y_max: float) -> ndarray:
+                              x_min: float, x_max: float, y_min: float, y_max: float, exact) -> ndarray:
         return GPUBackend._fast_2d(target, 0, x, y, np.zeros(len(target)), mass, rho, h, weight_function, kernel_radius,
                                    x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2)
 

--- a/sarracen/interpolate/gpu_backend.py
+++ b/sarracen/interpolate/gpu_backend.py
@@ -7,7 +7,7 @@ from numba.core.registry import CPUDispatcher
 from numpy import ndarray
 
 from sarracen.interpolate.base_backend import BaseBackend
-from sarracen.kernels.cubic_spline_exact import pint, wallint
+from sarracen.kernels.cubic_spline_exact import line_int, surface_int
 
 
 class GPUBackend(BaseBackend):
@@ -223,7 +223,7 @@ class GPUBackend(BaseBackend):
                         r0 = 0.5 * pixwidthy - dy
                         d1 = 0.5 * pixwidthx + dx
                         d2 = 0.5 * pixwidthx - dx
-                        pixint = pint(r0, d1, d2, h_data[i])
+                        pixint = line_int(r0, d1, d2, h_data[i])
                         wab = pixint * denom
 
                         cuda.atomic.add(image, (jpixmin, ipix), term * wab)
@@ -240,7 +240,7 @@ class GPUBackend(BaseBackend):
                         r0 = 0.5 * pixwidthx - dx
                         d1 = 0.5 * pixwidthy - dy
                         d2 = 0.5 * pixwidthy + dy
-                        pixint = pint(r0, d1, d2, h_data[i])
+                        pixint = line_int(r0, d1, d2, h_data[i])
                         wab = pixint * denom
 
                         cuda.atomic.add(image, (jpix, ipixmin), term * wab)
@@ -257,7 +257,7 @@ class GPUBackend(BaseBackend):
                         r0 = 0.5 * pixwidthy + dy
                         d1 = 0.5 * pixwidthx - dx
                         d2 = 0.5 * pixwidthx + dx
-                        pixint = pint(r0, d1, d2, h_data[i])
+                        pixint = line_int(r0, d1, d2, h_data[i])
                         wab = pixint * denom
 
                         # The negative value of the bottom boundary is equal to the value of the top boundary of the
@@ -270,7 +270,7 @@ class GPUBackend(BaseBackend):
                         r0 = 0.5 * pixwidthx + dx
                         d1 = 0.5 * pixwidthy + dy
                         d2 = 0.5 * pixwidthy - dy
-                        pixint = pint(r0, d1, d2, h_data[i])
+                        pixint = line_int(r0, d1, d2, h_data[i])
                         wab = pixint * denom
 
                         cuda.atomic.add(image, (jpix, ipix), term * wab)
@@ -437,20 +437,20 @@ class GPUBackend(BaseBackend):
                             # surface integrals of each surface of the cube.
 
                             # x-y surfaces
-                            pixint = 2 * wallint(0.5 * pixwidthz, x_data[i], y_data[i], xpix, ypix, pixwidthx,
-                                                 pixwidthy, h_data[i])
+                            pixint = 2 * surface_int(0.5 * pixwidthz, x_data[i], y_data[i], xpix, ypix, pixwidthx,
+                                                     pixwidthy, h_data[i])
 
                             # x-z surfaces
-                            pixint += wallint(ypix - y_data[i] + 0.5 * pixwidthy, x_data[i], 0, xpix, 0, pixwidthx,
-                                              pixwidthz, h_data[i])
-                            pixint += wallint(y_data[i] - ypix + 0.5 * pixwidthy, x_data[i], 0, xpix, 0, pixwidthx,
-                                              pixwidthz, h_data[i])
+                            pixint += surface_int(ypix - y_data[i] + 0.5 * pixwidthy, x_data[i], 0, xpix, 0, pixwidthx,
+                                                  pixwidthz, h_data[i])
+                            pixint += surface_int(y_data[i] - ypix + 0.5 * pixwidthy, x_data[i], 0, xpix, 0, pixwidthx,
+                                                  pixwidthz, h_data[i])
 
                             # y-z surfaces
-                            pixint += wallint(xpix - x_data[i] + 0.5 * pixwidthx, 0, y_data[i], 0, ypix, pixwidthz,
-                                              pixwidthy, h_data[i])
-                            pixint += wallint(x_data[i] - xpix + 0.5 * pixwidthx, 0, y_data[i], 0, ypix, pixwidthz,
-                                              pixwidthy, h_data[i])
+                            pixint += surface_int(xpix - x_data[i] + 0.5 * pixwidthx, 0, y_data[i], 0, ypix, pixwidthz,
+                                                  pixwidthy, h_data[i])
+                            pixint += surface_int(x_data[i] - xpix + 0.5 * pixwidthx, 0, y_data[i], 0, ypix, pixwidthz,
+                                                  pixwidthy, h_data[i])
 
                             wab = pixint * dfac
 

--- a/sarracen/interpolate/gpu_backend.py
+++ b/sarracen/interpolate/gpu_backend.py
@@ -36,9 +36,9 @@ class GPUBackend(BaseBackend):
                                              y1, y2)
 
     @staticmethod
-    def interpolate_3d_projection(target: ndarray, x: ndarray, y: ndarray, mass: ndarray, rho: ndarray, h: ndarray,
+    def interpolate_3d_projection(target: ndarray, x: ndarray, y: ndarray, z: ndarray, mass: ndarray, rho: ndarray, h: ndarray,
                                   weight_function: CPUDispatcher, kernel_radius: float, x_pixels: int, y_pixels: int,
-                                  x_min: float, x_max: float, y_min: float, y_max: float) -> ndarray:
+                                  x_min: float, x_max: float, y_min: float, y_max: float, exact: bool) -> ndarray:
         return GPUBackend._fast_2d(target, 0, x, y, np.zeros(len(target)), mass, rho, h, weight_function, kernel_radius,
                                    x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2)
 

--- a/sarracen/interpolate/interpolate.py
+++ b/sarracen/interpolate/interpolate.py
@@ -456,10 +456,10 @@ def interpolate_2d_cross(data: 'SarracenDataFrame', target: str, x: str = None, 
                               x2, y1, y2)
 
 
-def interpolate_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None, kernel: BaseKernel = None,
-                   integral_samples: int = 1000, rotation: np.ndarray = None, origin: np.ndarray = None,
-                   x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None,
-                   y_min: float = None, y_max: float = None, backend: str = None):
+def interpolate_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None, z: str = None,
+                   kernel: BaseKernel = None, integral_samples: int = 1000, rotation: np.ndarray = None,
+                   origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None, x_min: float = None,
+                   x_max: float = None, y_min: float = None, y_max: float = None, exact: bool = False, backend: str = None):
     """ Interpolate 3D particle data to a 2D grid of pixels.
 
     Interpolates three-dimensional particle data in a SarracenDataFrame. The data
@@ -522,16 +522,16 @@ def interpolate_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str
     x_pixels, y_pixels = _set_pixels(x_pixels, y_pixels, x_min, x_max, y_min, y_max)
     _check_boundaries(x_pixels, y_pixels, x_min, x_max, y_min, y_max)
 
-    x_data, y_data, _ = _rotate_xyz(data, x, y, data.zcol, rotation, origin)
+    x_data, y_data, z_data = _rotate_xyz(data, x, y, data.zcol, rotation, origin)
     kernel = kernel if kernel is not None else data.kernel
     backend = backend if backend is not None else data.backend
 
     weight_function = kernel.get_column_kernel_func(integral_samples)
 
     return get_backend(backend). \
-        interpolate_3d_projection(data[target].to_numpy(), x_data, y_data, data['m'].to_numpy(), data['rho'].to_numpy(),
-                                  data['h'].to_numpy(), weight_function, kernel.get_radius(), x_pixels, y_pixels, x_min,
-                                  x_max, y_min, y_max)
+        interpolate_3d_projection(data[target].to_numpy(), x_data, y_data, z_data, data['m'].to_numpy(),
+                                  data['rho'].to_numpy(), data['h'].to_numpy(), weight_function, kernel.get_radius(),
+                                  x_pixels, y_pixels, x_min, x_max, y_min, y_max, exact)
 
 
 def interpolate_3d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, target_z: str, x: str = None,

--- a/sarracen/interpolate/interpolate.py
+++ b/sarracen/interpolate/interpolate.py
@@ -333,7 +333,8 @@ def interpolate_2d(data: 'SarracenDataFrame', target: str, x: str = None, y: str
 
 def interpolate_2d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, x: str = None, y: str = None,
                        kernel: BaseKernel = None, x_pixels: int = None, y_pixels: int = None, x_min: float = None,
-                       x_max: float = None, y_min: float = None, y_max: float = None, backend: str = None):
+                       x_max: float = None, y_min: float = None, y_max: float = None, exact: bool = False,
+                       backend: str = None):
     """ Interpolate vector particle data across two directional axes to a 2D grid of particles.
 
     Interpolate the data within a SarracenDataFrame to a 2D grid, by interpolating the values
@@ -356,6 +357,8 @@ def interpolate_2d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, 
     x_min, x_max, y_min, y_max: float, optional
         The minimum and maximum values to use in interpolation, in particle data space. Defaults
         to the minimum and maximum values of `x` and `y`.
+    exact: bool
+        Whether to use exact interpolation of the data.
     backend: ['cpu', 'gpu']
         The computation backend to use when interpolating this data. Defaults to the backend specified in `data`.
 
@@ -391,7 +394,7 @@ def interpolate_2d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, 
         interpolate_2d_render_vec(data[target_x].to_numpy(), data[target_y].to_numpy(), data[x].to_numpy(),
                                   data[y].to_numpy(), data['m'].to_numpy(), data['rho'].to_numpy(),
                                   data['h'].to_numpy(), kernel.w, kernel.get_radius(), x_pixels, y_pixels, x_min, x_max,
-                                  y_min, y_max)
+                                  y_min, y_max, exact)
 
 
 def interpolate_2d_cross(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None,
@@ -456,10 +459,10 @@ def interpolate_2d_cross(data: 'SarracenDataFrame', target: str, x: str = None, 
                               x2, y1, y2)
 
 
-def interpolate_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None, z: str = None,
-                   kernel: BaseKernel = None, integral_samples: int = 1000, rotation: np.ndarray = None,
-                   origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None, x_min: float = None,
-                   x_max: float = None, y_min: float = None, y_max: float = None, exact: bool = False, backend: str = None):
+def interpolate_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None, kernel: BaseKernel = None,
+                   integral_samples: int = 1000, rotation: np.ndarray = None, origin: np.ndarray = None,
+                   x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None,
+                   y_min: float = None, y_max: float = None, exact: bool = False, backend: str = None):
     """ Interpolate 3D particle data to a 2D grid of pixels.
 
     Interpolates three-dimensional particle data in a SarracenDataFrame. The data
@@ -490,6 +493,8 @@ def interpolate_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str
     x_min, x_max, y_min, y_max: float, optional
         The minimum and maximum values to use in interpolation, in particle data space. Defaults
         to the minimum and maximum values of `x` and `y`.
+    exact: bool
+        Whether to use exact interpolation of the data.
     backend: ['cpu', 'gpu']
         The computation backend to use when interpolating this data. Defaults to the backend specified in `data`.
 
@@ -538,7 +543,7 @@ def interpolate_3d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, 
                        y: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
                        rotation: np.ndarray = None, origin: np.ndarray = None, x_pixels: int = None,
                        y_pixels: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
-                       y_max: float = None, backend: str = None):
+                       y_max: float = None, exact: bool = False, backend: str = None):
     """ Interpolate 3D vector particle data to a 2D grid of pixels.
 
         Interpolates three-dimensional vector particle data in a SarracenDataFrame. The data
@@ -569,6 +574,8 @@ def interpolate_3d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, 
         x_min, x_max, y_min, y_max: float, optional
             The minimum and maximum values to use in interpolation, in particle data space. Defaults
             to the minimum and maximum values of `x` and `y`.
+        exact: bool
+            Whether to use exact interpolation of the data.
         backend: ['cpu', 'gpu']
             The computation backend to use when interpolating this data. Defaults to the backend specified in `data`.
 
@@ -614,7 +621,7 @@ def interpolate_3d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, 
     return get_backend(backend). \
         interpolate_3d_projection_vec(target_x_data, target_y_data, x_data, y_data, data['m'].to_numpy(),
                                       data['rho'].to_numpy(), data['h'].to_numpy(), weight_function,
-                                      kernel.get_radius(), x_pixels, y_pixels, x_min, x_max, y_min, y_max)
+                                      kernel.get_radius(), x_pixels, y_pixels, x_min, x_max, y_min, y_max, exact)
 
 
 def interpolate_3d_cross(data: 'SarracenDataFrame', target: str, z_slice: float = None, x: str = None, y: str = None,
@@ -739,8 +746,7 @@ def interpolate_3d_cross_vec(data: 'SarracenDataFrame', target_x: str, target_y:
             The minimum and maximum values to use in interpolation, in particle data space. Defaults
             to the minimum and maximum values of `x` and `y`.
         backend: ['cpu', 'gpu']
-        The computation backend to use when interpolating this data. Defaults to the backend specified in `data`.
-
+            The computation backend to use when interpolating this data. Defaults to the backend specified in `data`.
 
         Returns
         -------

--- a/sarracen/interpolate/interpolate.py
+++ b/sarracen/interpolate/interpolate.py
@@ -270,7 +270,7 @@ def _rotate_xyz(data, x, y, z, rotation, origin):
 
 def interpolate_2d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None, kernel: BaseKernel = None,
                    x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None,
-                   y_min: float = None, y_max: float = None, backend: str = None) -> np.ndarray:
+                   y_min: float = None, y_max: float = None, exact: bool = False, backend: str = None) -> np.ndarray:
     """ Interpolate particle data across two directional axes to a 2D grid of pixels.
 
     Interpolate the data within a SarracenDataFrame to a 2D grid, by interpolating the values
@@ -293,6 +293,8 @@ def interpolate_2d(data: 'SarracenDataFrame', target: str, x: str = None, y: str
     x_min, x_max, y_min, y_max: float, optional
         The minimum and maximum values to use in interpolation, in particle data space. Defaults
         to the minimum and maximum values of `x` and `y`.
+    exact: bool
+        Whether to use exact interpolation of the data.
     backend: ['cpu', 'gpu']
         The computation backend to use when interpolating this data. Defaults to the backend specified in `data`.
 
@@ -326,7 +328,7 @@ def interpolate_2d(data: 'SarracenDataFrame', target: str, x: str = None, y: str
     return get_backend(backend). \
         interpolate_2d_render(data[target].to_numpy(), data[x].to_numpy(), data[y].to_numpy(), data['m'].to_numpy(),
                               data['rho'].to_numpy(), data['h'].to_numpy(), kernel.w, kernel.get_radius(), x_pixels,
-                              y_pixels, x_min, x_max, y_min, y_max)
+                              y_pixels, x_min, x_max, y_min, y_max, exact)
 
 
 def interpolate_2d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, x: str = None, y: str = None,

--- a/sarracen/kernels/cubic_spline_exact.py
+++ b/sarracen/kernels/cubic_spline_exact.py
@@ -1,4 +1,5 @@
-import numpy as np
+import math
+
 from numba import njit
 
 
@@ -14,8 +15,8 @@ def pint(r0, d1, d2, hi1):
         ar0 = -r0
 
     q0 = ar0 * hi1
-    phi1 = np.arctan(abs(d1) / ar0)
-    phi2 = np.arctan(abs(d2) / ar0)
+    phi1 = math.atan(abs(d1) / ar0)
+    phi2 = math.atan(abs(d2) / ar0)
 
     if d1 * d2 >= 0:
         result = result * (full_2d_mod(phi1, q0) + full_2d_mod(phi2, q0))
@@ -30,27 +31,27 @@ def pint(r0, d1, d2, hi1):
 @njit
 def full_2d_mod(phi, q0):
     if q0 <= 1.0:
-        cphi = np.cos(phi)
+        cphi = math.cos(phi)
         q = q0 / cphi
 
         if q <= 1.0:
             return F1_2d(phi, q0)
         elif q <= 2.0:
-            phi1 = np.arccos(q0)
+            phi1 = math.acos(q0)
             return F2_2d(phi, q0) - F2_2d(phi1, q0) + F1_2d(phi1, q0)
         else:
-            phi1 = np.arccos(q0)
-            phi2 = np.arccos(0.5 * q0)
+            phi1 = math.acos(q0)
+            phi2 = math.acos(0.5 * q0)
             return F3_2d(phi) - F3_2d(phi2) + F2_2d(phi2, q0) - F2_2d(phi1, q0) + F1_2d(
                 phi1, q0)
     elif q0 <= 2.0:
-        cphi = np.cos(phi)
+        cphi = math.cos(phi)
         q = q0 / cphi
 
         if q <= 2.0:
             return F2_2d(phi, q0)
         else:
-            phi2 = np.arccos(0.5 * q0)
+            phi2 = math.acos(0.5 * q0)
             return F3_2d(phi) - F3_2d(phi2) + F2_2d(phi2, q0)
     else:
         return F3_2d(phi)
@@ -58,42 +59,42 @@ def full_2d_mod(phi, q0):
 
 @njit
 def F1_2d(phi, q0):
-    cphi2 = np.cos(phi) ** 2
+    cphi2 = math.cos(phi) ** 2
 
-    logs = np.log(np.tan(phi / 2. + np.pi / 4.))
+    logs = math.log(math.tan(phi / 2. + math.pi / 4.))
 
-    I2 = np.tan(phi)
-    I4 = 1. / 3. * np.tan(phi) * (2. + 1. / cphi2)
+    I2 = math.tan(phi)
+    I4 = 1. / 3. * math.tan(phi) * (2. + 1. / cphi2)
 
-    I5 = 1. / 16. * (0.5 * (11. * np.sin(phi) + 3. * np.sin(3. * phi)) / cphi2 / cphi2 + 6. * logs)
+    I5 = 1. / 16. * (0.5 * (11. * math.sin(phi) + 3. * math.sin(3. * phi)) / cphi2 / cphi2 + 6. * logs)
 
-    return 5. / 7. * q0 ** 2 / np.pi * (I2 - 3. / 4. * q0 ** 2 * I4 + 0.3 * q0 ** 3 * I5)
+    return 5. / 7. * q0 ** 2 / math.pi * (I2 - 3. / 4. * q0 ** 2 * I4 + 0.3 * q0 ** 3 * I5)
 
 
 @njit
 def F2_2d(phi, q0):
-    cphi2 = np.cos(phi) ** 2
+    cphi2 = math.cos(phi) ** 2
 
     q02 = q0 * q0
     q03 = q02 * q0
 
-    logs = np.log(np.tan(phi / 2. + np.pi / 4.))
+    logs = math.log(math.tan(phi / 2. + math.pi / 4.))
 
     I0 = phi
-    I2 = np.tan(phi)
-    I4 = 1. / 3. * np.tan(phi) * (2. + 1. / cphi2)
+    I2 = math.tan(phi)
+    I4 = 1. / 3. * math.tan(phi) * (2. + 1. / cphi2)
 
-    I3 = 1. / 2. * (np.tan(phi) / np.cos(phi) + logs)
-    I5 = 1. / 16. * (0.5 * (11. * np.sin(phi) + 3. * np.sin(3. * phi)) / cphi2 / cphi2 + 6. * logs)
+    I3 = 1. / 2. * (math.tan(phi) / math.cos(phi) + logs)
+    I5 = 1. / 16. * (0.5 * (11. * math.sin(phi) + 3. * math.sin(3. * phi)) / cphi2 / cphi2 + 6. * logs)
 
-    return 5. / 7. * q02 / np.pi * (
+    return 5. / 7. * q02 / math.pi * (
             2. * I2 - 2. * q0 * I3 + 3. / 4. * q02 * I4 - 1. / 10. * q03 * I5 - 1. / 10. / q02 * I0)
 
 
 @njit
 def F3_2d(phi):
     I0 = phi
-    return 0.5 / np.pi * I0
+    return 0.5 / math.pi * I0
 
 
 @njit
@@ -171,8 +172,8 @@ def pint3D(r0, R_0, d1, d2, hi):
 @njit
 def full_integral_3D(d, r0, R_0, h):
     r0h = r0 / h
-    tanphi = abs(d) / R_0
-    phi = np.arctan(tanphi)
+    tamathhi = abs(d) / R_0
+    phi = math.atan(tamathhi)
 
     if abs(r0h) == 0 or abs(R_0 / h) == 0 or abs(phi) == 0:
         return 0
@@ -200,7 +201,7 @@ def full_integral_3D(d, r0, R_0, h):
     a2 = a * a
 
     linedist2 = (r0 * r0 + R_0 * R_0)
-    cosphi = np.cos(phi)
+    cosphi = math.cos(phi)
     R_ = R_0 / cosphi
     r2 = (r0 * r0 + R_ * R_)
 
@@ -208,13 +209,13 @@ def full_integral_3D(d, r0, R_0, h):
     D3 = 0.0
 
     if linedist2 < h2:
-        cosp = R_0 / np.sqrt(h2 - r0 * r0)
+        cosp = R_0 / math.sqrt(h2 - r0 * r0)
         I0, I1, I_2, I_3, I_4, I_5 = get_I_terms(cosp, a2, a)
 
         D2 = -1. / 6. * I_2 + 0.25 * (r0h) * I_3 - 0.15 * r0h2 * I_4 + 1. / 30. * r0h3 * I_5 - 1. / 60. * r0h_3 * I1 + (
                 B1 - B2) / r03 * I0
     if linedist2 < 4. * h2:
-        cosp = R_0 / np.sqrt(4.0 * h2 - r0 * r0)
+        cosp = R_0 / math.sqrt(4.0 * h2 - r0 * r0)
         I0, I1, I_2, I_3, I_4, I_5 = get_I_terms(cosp, a2, a)
 
         if B2 is None:
@@ -224,36 +225,32 @@ def full_integral_3D(d, r0, R_0, h):
             r0h) * I_3 + 3. / 40. * r0h2 * I_4 - 1. / 120. * r0h3 * I_5 + 4. / 15. * r0h_3 * I1 + (
                      B2 - B3) / r03 * I0 + D2
 
-    I0, I1, I_2, I_3, I_4, I_5 = get_I_terms(cosphi, a2, a, phi=phi, tanphi=tanphi)
+    I0, I1, I_2, I_3, I_4, I_5 = get_I_terms(cosphi, a2, a)
 
     if r2 <= h2:
-        return r0h3 / np.pi * (1. / 6. * I_2 - 3. / 40. * r0h2 * I_4 + 1. / 40. * r0h3 * I_5 + B1 / r03 * I0)
+        return r0h3 / math.pi * (1. / 6. * I_2 - 3. / 40. * r0h2 * I_4 + 1. / 40. * r0h3 * I_5 + B1 / r03 * I0)
     elif r2 <= 4. * h2:
-        return r0h3 / np.pi * (0.25 * (4. / 3. * I_2 - (
+        return r0h3 / math.pi * (0.25 * (4. / 3. * I_2 - (
                 r0 / h) * I_3 + 0.3 * r0h2 * I_4 - 1. / 30. * r0h3 * I_5 + 1. / 15. * r0h_3 * I1) + B2 / r03 * I0 + D2)
     else:
-        return r0h3 / np.pi * (-0.25 * r0h_3 * I1 + B3 / r03 * I0 + D3)
+        return r0h3 / math.pi * (-0.25 * r0h_3 * I1 + B3 / r03 * I0 + D3)
 
 
 @njit
-def get_I_terms(cosp, a2, a, phi=None, tanphi=None):
+def get_I_terms(cosp, a2, a):
     cosp2 = cosp * cosp
-    if phi:
-        p = phi
-        tanp = tanphi
-    else:
-        p = np.arccos(cosp)
-        tanp = np.sqrt(1. - cosp2) / cosp
+    p = math.acos(cosp)
+    tamath = math.sqrt(1. - cosp2) / cosp
 
     mu2_1 = 1. / (1. + cosp2 / a2)
     I0 = p
-    I_2 = p + a2 * tanp
-    I_4 = p + 2. * a2 * tanp + 1. / 3. * a2 * a2 * tanp * (2. + 1. / cosp2)
+    I_2 = p + a2 * tamath
+    I_4 = p + 2. * a2 * tamath + 1. / 3. * a2 * a2 * tamath * (2. + 1. / cosp2)
 
     u2 = (1. - cosp2) * mu2_1
-    u = np.sqrt(u2)
-    logs = np.log((1. + u) / (1. - u))
-    I1 = np.arctan2(u, a)
+    u = math.sqrt(u2)
+    logs = math.log((1. + u) / (1. - u))
+    I1 = math.atan2(u, a)
 
     fac = 1. / (1. - u2)
     I_1 = 0.5 * a * logs + I1

--- a/sarracen/kernels/cubic_spline_exact.py
+++ b/sarracen/kernels/cubic_spline_exact.py
@@ -4,7 +4,24 @@ from numba import njit
 
 
 @njit
-def pint(r0, d1, d2, hi1):
+def pint(r0, d1, d2, h):
+    """ Calculate an exact 2D line integral over the cubic spline kernel.
+
+    Used in exact calculation of a pixel surface integral in 2D.
+
+    Parameters
+    ----------
+    r0: float
+        Distance between the contributing particle and the line.
+    d1, d2: float
+        Distance from the endpoint of `r0` to each endpoint of the line.
+    h: float
+        Smoothing length of the contributing particle.
+
+    Returns
+    -------
+    float: The exact value of this line integral.
+    """
     if r0 == 0:
         return 0
     elif r0 > 0:
@@ -14,65 +31,127 @@ def pint(r0, d1, d2, hi1):
         result = -1
         ar0 = -r0
 
-    q0 = ar0 * hi1
+    q0 = ar0 / h
+
+    # Determine the angle between q0 and the endpoints of the line, relative to the contributing particle.
     phi1 = math.atan(abs(d1) / ar0)
     phi2 = math.atan(abs(d2) / ar0)
 
     if d1 * d2 >= 0:
-        result = result * (full_2d_mod(phi1, q0) + full_2d_mod(phi2, q0))
+        # Both line endpoints are on opposite sides of r0.
+        result = result * (_full_2d_mod(phi1, q0) + _full_2d_mod(phi2, q0))
     elif abs(d1) < abs(d2):
-        result = result * (full_2d_mod(phi2, q0) - full_2d_mod(phi1, q0))
+        # Both line endpoints are on the same side of r0, with d2 having a larger magnitude.
+        result = result * (_full_2d_mod(phi2, q0) - _full_2d_mod(phi1, q0))
     else:
-        result = result * (full_2d_mod(phi1, q0) - full_2d_mod(phi2, q0))
+        # Both line endpoints are on the same side of r0, with d1 having a larger magnitude.
+        result = result * (_full_2d_mod(phi1, q0) - _full_2d_mod(phi2, q0))
 
     return result
 
 
 @njit
-def full_2d_mod(phi, q0):
+def _full_2d_mod(phi, q0):
+    """ Calculate an exact 2D line integral over the cubic spline kernel.
+
+    Assumes that one endpoint of the line is at the end of `q0`. Used in pint.
+
+    Parameters
+    ----------
+    phi: float
+        Angle between `q0` and the endpoint of the line, relative to the contributing particle.
+    q0: float
+        The distance between the contributing particle and the line, scaled by the smoothing length of the particle.
+
+    Returns
+    -------
+    float: The exact value of this line integral.
+    """
     if q0 <= 1.0:
-        cphi = math.cos(phi)
-        q = q0 / cphi
+        # At least part of the line lies within 0 < q <= 1
+        q = q0 / math.cos(phi)
 
         if q <= 1.0:
-            return F1_2d(phi, q0)
+            # The line lies entirely within 0 < q <= 1.
+            return _f1_2d(phi, q0)
         elif q <= 2.0:
+            # The line lies partly in 0 < q <= 1 and partly in 1 < q <= 2.
+
+            # Angle between q0 and the line region endpoint within 0 < q <= 1, relative to the contributing particle.
             phi1 = math.acos(q0)
-            return F2_2d(phi, q0) - F2_2d(phi1, q0) + F1_2d(phi1, q0)
+            return _f2_2d(phi, q0) - _f2_2d(phi1, q0) + _f1_2d(phi1, q0)
         else:
+            # The line spans all three possible regions, 0 < q <= 1, 1 < q <= 2, and q > 2.
+
+            # Angle between q0 and the line region endpoint within 0 < q <= 1, relative to the contributing particle.
             phi1 = math.acos(q0)
+            # Angle between q0 and the line region endpoint within 1 < q <= 2, relative to the contributing particle.
             phi2 = math.acos(0.5 * q0)
-            return F3_2d(phi) - F3_2d(phi2) + F2_2d(phi2, q0) - F2_2d(phi1, q0) + F1_2d(
-                phi1, q0)
+            return _f3_2d(phi) - _f3_2d(phi2) + _f2_2d(phi2, q0) - _f2_2d(phi1, q0) + _f1_2d(phi1, q0)
     elif q0 <= 2.0:
-        cphi = math.cos(phi)
-        q = q0 / cphi
+        # No part of the line lies within 0 < q <= 1, but it does lie within 1 < q <= 2.
+        q = q0 / math.cos(phi)
 
         if q <= 2.0:
-            return F2_2d(phi, q0)
+            # The line lies entirely within 1 < q <= 2.
+            return _f2_2d(phi, q0)
         else:
+            # The line lies partly in 1 < q <= 2 and q > 2.
+
+            # Angle between q0 and the line region endpoint within 1 < q <= 2, relative to the contributing particle.
             phi2 = math.acos(0.5 * q0)
-            return F3_2d(phi) - F3_2d(phi2) + F2_2d(phi2, q0)
+            return _f3_2d(phi) - _f3_2d(phi2) + _f2_2d(phi2, q0)
     else:
-        return F3_2d(phi)
+        # The line lies entirely within q > 2.
+        return _f3_2d(phi)
 
 
 @njit
-def F1_2d(phi, q0):
-    cphi2 = math.cos(phi) ** 2
+def _f1_2d(phi, q0):
+    """ Calculate an exact 2D line integral over the cubic spline kernel.
 
+    Assumes that one endpoint of the line is at the end of `q0`. Only valid for 0 < q <= 1.
+    Used in _full_2d_mod.
+
+    Parameters
+    ----------
+    phi: float
+        Angle between `q0` and the endpoint of the line segment, relative to the contributing particle.
+    q0: float
+        The distance between the contributing particle and the line, scaled by the smoothing length of the particle.
+
+    Returns
+    -------
+    float: The exact value of this line integral segment.
+    """
+    cphi2 = math.cos(phi) ** 2
     logs = math.log(math.tan(phi / 2. + math.pi / 4.))
 
-    I2 = math.tan(phi)
-    I4 = 1. / 3. * math.tan(phi) * (2. + 1. / cphi2)
+    i2 = math.tan(phi)
+    i4 = 1. / 3. * math.tan(phi) * (2. + 1. / cphi2)
+    i5 = 1. / 16. * (0.5 * (11. * math.sin(phi) + 3. * math.sin(3. * phi)) / cphi2 / cphi2 + 6. * logs)
 
-    I5 = 1. / 16. * (0.5 * (11. * math.sin(phi) + 3. * math.sin(3. * phi)) / cphi2 / cphi2 + 6. * logs)
-
-    return 5. / 7. * q0 ** 2 / math.pi * (I2 - 3. / 4. * q0 ** 2 * I4 + 0.3 * q0 ** 3 * I5)
+    return 5. / 7. * q0 ** 2 / math.pi * (i2 - 3. / 4. * q0 ** 2 * i4 + 0.3 * q0 ** 3 * i5)
 
 
 @njit
-def F2_2d(phi, q0):
+def _f2_2d(phi, q0):
+    """ Calculate an exact 2D line integral over the cubic spline kernel.
+
+    Assumes that one endpoint of the line is at the end of `q0`. Only valid for 1 < q <= 2.
+    Used in _full_2d_mod.
+
+    Parameters
+    ----------
+    phi: float
+        Angle between `q0` and the endpoint of the line segment, relative to the contributing particle.
+    q0: float
+        The distance between the contributing particle and the line, scaled by the smoothing length of the particle.
+
+    Returns
+    -------
+    float: The exact value of this line integral segment.
+    """
     cphi2 = math.cos(phi) ** 2
 
     q02 = q0 * q0
@@ -80,73 +159,129 @@ def F2_2d(phi, q0):
 
     logs = math.log(math.tan(phi / 2. + math.pi / 4.))
 
-    I0 = phi
-    I2 = math.tan(phi)
-    I4 = 1. / 3. * math.tan(phi) * (2. + 1. / cphi2)
-
-    I3 = 1. / 2. * (math.tan(phi) / math.cos(phi) + logs)
-    I5 = 1. / 16. * (0.5 * (11. * math.sin(phi) + 3. * math.sin(3. * phi)) / cphi2 / cphi2 + 6. * logs)
+    i0 = phi
+    i2 = math.tan(phi)
+    i3 = 1. / 2. * (math.tan(phi) / math.cos(phi) + logs)
+    i4 = 1. / 3. * math.tan(phi) * (2. + 1. / cphi2)
+    i5 = 1. / 16. * (0.5 * (11. * math.sin(phi) + 3. * math.sin(3. * phi)) / cphi2 / cphi2 + 6. * logs)
 
     return 5. / 7. * q02 / math.pi * (
-            2. * I2 - 2. * q0 * I3 + 3. / 4. * q02 * I4 - 1. / 10. * q03 * I5 - 1. / 10. / q02 * I0)
+            2. * i2 - 2. * q0 * i3 + 3. / 4. * q02 * i4 - 1. / 10. * q03 * i5 - 1. / 10. / q02 * i0)
 
 
 @njit
-def F3_2d(phi):
-    I0 = phi
-    return 0.5 / math.pi * I0
+def _f3_2d(phi):
+    """ Calculate an exact 2D line integral over the cubic spline kernel.
+
+    Assumes that one endpoint of the line is at the end of `q0`. Only valid for q > 2.
+    Used in _full_2d_mod.
+
+    Parameters
+    ----------
+    phi: float
+        Angle pointing towards the endpoint of the line segment, relative to the contributing particle.
+
+    Returns
+    -------
+    float: The exact value of this line integral segment.
+    """
+    return 0.5 / math.pi * phi
 
 
 @njit
-def wallint(r0, xp, yp, xc, yc, pixwidthx, pixwidthy, hi):
+def wallint(r0, x1, y1, x2, y2, wx, wy, h):
+    """ Calculate an exact 3D surface integral over the cubic spline kernel.
+
+    Used to exactly calculating the contribution of a particle to a pixel's volume in 3D space.
+
+    Parameters
+    ----------
+    r0: float
+        Distance between the contributing particle and the target surface.
+    x1, y1, x2, y2: float
+        Upper and lower bounds of the target surface, relative to r0.
+    wx, wy: float
+        The size of a single pixel.
+    h: float
+        The smoothing length of the contributing particle.
+
+    Returns
+    -------
+    float: The exact value of this surface integral.
+    """
     result = 0.0
-    dx = xc - xp
-    dy = yc - yp
-    h = hi
+    dx = x2 - x1
+    dy = y2 - y1
 
-    R_0 = 0.5 * pixwidthy + dy
-    d1 = 0.5 * pixwidthx - dx
-    d2 = 0.5 * pixwidthx + dx
-    result = result + pint3D(r0, R_0, d1, d2, h)
+    # Calculate the exact value of this surface by summing the comprising line integrals.
 
-    R_0 = 0.5 * pixwidthy - dy
-    d1 = 0.5 * pixwidthx + dx
-    d2 = 0.5 * pixwidthx - dx
-    result = result + pint3D(r0, R_0, d1, d2, h)
+    # Bottom boundary
+    r1 = 0.5 * wy + dy
+    d1 = 0.5 * wx - dx
+    d2 = 0.5 * wx + dx
+    result = result + _pint3d(r0, r1, d1, d2, h)
 
-    R_0 = 0.5 * pixwidthx + dx
-    d1 = 0.5 * pixwidthy + dy
-    d2 = 0.5 * pixwidthy - dy
-    result = result + pint3D(r0, R_0, d1, d2, h)
+    # Top boundary
+    r1 = 0.5 * wy - dy
+    d1 = 0.5 * wx + dx
+    d2 = 0.5 * wx - dx
+    result = result + _pint3d(r0, r1, d1, d2, h)
 
-    R_0 = 0.5 * pixwidthx - dx
-    d1 = 0.5 * pixwidthy - dy
-    d2 = 0.5 * pixwidthy + dy
-    result = result + pint3D(r0, R_0, d1, d2, h)
+    # Right boundary
+    r1 = 0.5 * wx + dx
+    d1 = 0.5 * wy + dy
+    d2 = 0.5 * wy - dy
+    result = result + _pint3d(r0, r1, d1, d2, h)
+
+    # Left boundary
+    r1 = 0.5 * wx - dx
+    d1 = 0.5 * wy - dy
+    d2 = 0.5 * wy + dy
+    result = result + _pint3d(r0, r1, d1, d2, h)
 
     return result
 
 
 @njit
-def pint3D(r0, R_0, d1, d2, hi):
+def _pint3d(r0, r1, d1, d2, h):
+    """ Calculate an exact 3D line integral over the cubic spline kernel.
+
+    Used in wallint.
+
+    Parameters
+    ----------
+    r0: float
+        Distance between the contributing particle and the target surface.
+    r1: float
+        Distance between the endpoint of `r0` and the line.
+    d1, d2: float
+        Distance from the endpoint of `r1` to each endpoint of the line.
+    h: float
+        Smoothing length of the contributing particle.
+
+    Returns
+    -------
+    float: The exact value of this line integral.
+    """
     if abs(r0) == 0:
         return 0
-
-    if r0 > 0.:
+    if r0 > 0:
         result = 1
         ar0 = r0
     else:
         result = -1
         ar0 = -r0
 
-    if R_0 > 0.:
-        aR_0 = R_0
+    if r1 > 0.:
+        ar1 = r1
     else:
         result = -result
-        aR_0 = -R_0
+        ar1 = -r1
 
-    int1 = full_integral_3D(d1, ar0, aR_0, hi)
-    int2 = full_integral_3D(d2, ar0, aR_0, hi)
+    # Split this line integral into two separate line integrals, where one end point is at the endpoint of r1,
+    # and the other end point is d1 or d2 respectively.
+    int1 = _full_integral_3d(d1, ar0, ar1, h)
+    int2 = _full_integral_3d(d2, ar0, ar1, h)
 
     if int1 < 0:
         int1 = 0
@@ -154,14 +289,17 @@ def pint3D(r0, R_0, d1, d2, hi):
         int2 = 0
 
     if d1 * d2 >= 0:
+        # Both line endpoints are on opposite sides of r1.
         result = result * (int1 + int2)
         if int1 + int2 < 0:
             print('Error: int1 + int2 < 0')
     elif abs(d1) < abs(d2):
+        # Both line endpoints are on the same side of r1, with d2 having a larger magnitude.
         result = result * (int2 - int1)
         if int2 - int1 < 0:
             print('Error: int2 - int1 < 0: ', int1, int2, '(', d1, d2, ')')
     else:
+        # Both line endpoints are on the same side of r1, with d1 having a larger magnitude.
         result = result * (int1 - int2)
         if int1 - int2 < 0:
             print('Error: int1 - int2 < 0: ', int1, int2, '(', d1, d2, ')')
@@ -170,12 +308,31 @@ def pint3D(r0, R_0, d1, d2, hi):
 
 
 @njit
-def full_integral_3D(d, r0, R_0, h):
-    r0h = r0 / h
-    tamathhi = abs(d) / R_0
-    phi = math.atan(tamathhi)
+def _full_integral_3d(d, r0, r1, h):
+    """ Calculate an exact 3D line integral over the cubic spline kernel.
 
-    if abs(r0h) == 0 or abs(R_0 / h) == 0 or abs(phi) == 0:
+    Assumes that one endpoint of the line is at the end of `r1`. Used in _pint3d.
+
+    Parameters
+    ----------
+    d: float
+        Distance of the line.
+    r0: float
+        Distance between the target surface and the contributing particle.
+    r1: float
+        Distance between the end of `r0` and the line.
+    h: float
+        The smoothing length of the contributing particle.
+
+    Returns
+    -------
+    float: The exact value of this line integral.
+    """
+    r0h = r0 / h
+    # Angle between the end of the line and the end of r1, relative to the start of r1.
+    phi = math.atan(abs(d) / r1)
+
+    if abs(r0h) == 0 or abs(r1 / h) == 0 or abs(phi) == 0:
         return 0
 
     h2 = h * h
@@ -185,59 +342,64 @@ def full_integral_3D(d, r0, R_0, h):
     r0h_2 = 1. / r0h2
     r0h_3 = 1. / r0h3
 
-    B1 = None
-    B2 = None
+    b1 = None
+    b2 = None
     if r0 > 2.0 * h:
-        B3 = 0.25 * h2 * h
+        # The entire surface lies outside r > 2h.
+        b3 = 0.25 * h2 * h
     elif r0 > h:
-        B3 = 0.25 * r03 * (-4. / 3. + (r0h) - 0.3 * r0h2 + 1. / 30. * r0h3 - 1. / 15. * r0h_3 + 8. / 5. * r0h_2)
-        B2 = 0.25 * r03 * (-4. / 3. + (r0h) - 0.3 * r0h2 + 1. / 30. * r0h3 - 1. / 15. * r0h_3)
+        # A part of the surface lies in the region h < r <= 2h.
+        b3 = 0.25 * r03 * (-4. / 3. + r0h - 0.3 * r0h2 + 1. / 30. * r0h3 - 1. / 15. * r0h_3 + 8. / 5. * r0h_2)
+        b2 = 0.25 * r03 * (-4. / 3. + r0h - 0.3 * r0h2 + 1. / 30. * r0h3 - 1. / 15. * r0h_3)
     else:
-        B3 = 0.25 * r03 * (-2. / 3. + 0.3 * r0h2 - 0.1 * r0h3 + 7. / 5. * r0h_2)
-        B2 = 0.25 * r03 * (-2. / 3. + 0.3 * r0h2 - 0.1 * r0h3 - 1. / 5. * r0h_2)
-        B1 = 0.25 * r03 * (-2. / 3. + 0.3 * r0h2 - 0.1 * r0h3)
+        # A part of the surface lies in the region 0 < r <= h.
+        b3 = 0.25 * r03 * (-2. / 3. + 0.3 * r0h2 - 0.1 * r0h3 + 7. / 5. * r0h_2)
+        b2 = 0.25 * r03 * (-2. / 3. + 0.3 * r0h2 - 0.1 * r0h3 - 1. / 5. * r0h_2)
+        b1 = 0.25 * r03 * (-2. / 3. + 0.3 * r0h2 - 0.1 * r0h3)
 
-    a = R_0 / r0
+    a = r1 / r0
     a2 = a * a
 
-    linedist2 = (r0 * r0 + R_0 * R_0)
-    cosphi = math.cos(phi)
-    R_ = R_0 / cosphi
-    r2 = (r0 * r0 + R_ * R_)
+    # Squared distance between the contributing particle and the end of r1.
+    linedist2 = r0 * r0 + r1 * r1
+    # Distance between the end of r1 and the end of the line.
+    r_ = r1 / math.cos(phi)
+    # Squared distance between the contributing particle and the end of the line.
+    r2 = (r0 * r0 + r_ * r_)
 
-    D2 = 0.0
-    D3 = 0.0
+    d2 = 0.0
+    d3 = 0.0
 
     if linedist2 < h2:
-        cosp = R_0 / math.sqrt(h2 - r0 * r0)
-        I0, I1, I_2, I_3, I_4, I_5 = get_I_terms(cosp, a2, a)
+        # A portion of the line lies within 0 < r < h.
+        i = get_I_terms(r1 / math.sqrt(h2 - r0 * r0), a2, a)
 
-        D2 = -1. / 6. * I_2 + 0.25 * (r0h) * I_3 - 0.15 * r0h2 * I_4 + 1. / 30. * r0h3 * I_5 - 1. / 60. * r0h_3 * I1 + (
-                B1 - B2) / r03 * I0
+        d2 = -1. / 6. * i[2] + 0.25 * r0h * i[3] - 0.15 * r0h2 * i[4] + 1. / 30. * r0h3 * i[5] - 1. / 60. * r0h_3\
+             * i[1] + (b1 - b2) / r03 * i[0]
     if linedist2 < 4. * h2:
-        cosp = R_0 / math.sqrt(4.0 * h2 - r0 * r0)
-        I0, I1, I_2, I_3, I_4, I_5 = get_I_terms(cosp, a2, a)
+        # A portion of the line lies within 0 < r < 2h.
+        i = get_I_terms(r1 / math.sqrt(4.0 * h2 - r0 * r0), a2, a)
 
-        if B2 is None:
-            print("Ouch!")
+        d3 = 1. / 3. * i[2] - 0.25 * r0h * i[3] + 3. / 40. * r0h2 * i[4] - 1. / 120. * r0h3 * i[5] + 4. / 15. * r0h_3\
+             * i[1] + (b2 - b3) / r03 * i[0] + d2
 
-        D3 = 1. / 3. * I_2 - 0.25 * (
-            r0h) * I_3 + 3. / 40. * r0h2 * I_4 - 1. / 120. * r0h3 * I_5 + 4. / 15. * r0h_3 * I1 + (
-                     B2 - B3) / r03 * I0 + D2
-
-    I0, I1, I_2, I_3, I_4, I_5 = get_I_terms(cosphi, a2, a)
+    i = get_I_terms(math.cos(phi), a2, a)
 
     if r2 <= h2:
-        return r0h3 / math.pi * (1. / 6. * I_2 - 3. / 40. * r0h2 * I_4 + 1. / 40. * r0h3 * I_5 + B1 / r03 * I0)
+        # The entire line lies within 0 < r <= h.
+        return r0h3 / math.pi * (1. / 6. * i[2] - 3. / 40. * r0h2 * i[4] + 1. / 40. * r0h3 * i[5] + b1 / r03 * i[0])
     elif r2 <= 4. * h2:
-        return r0h3 / math.pi * (0.25 * (4. / 3. * I_2 - (
-                r0 / h) * I_3 + 0.3 * r0h2 * I_4 - 1. / 30. * r0h3 * I_5 + 1. / 15. * r0h_3 * I1) + B2 / r03 * I0 + D2)
+        # The entire line lies within 0 < r <= 2h.
+        return r0h3 / math.pi * (0.25 * (4. / 3. * i[2] - (r0 / h) * i[3] + 0.3 * r0h2 * i[4] - 1. / 30. * r0h3 * i[5] +
+                                         1. / 15. * r0h_3 * i[1]) + b2 / r03 * i[0] + d2)
     else:
-        return r0h3 / math.pi * (-0.25 * r0h_3 * I1 + B3 / r03 * I0 + D3)
+        # The line lies in all possible regions, 0 < r <= h, 0 < r <= 2h, and r > 2h.
+        return r0h3 / math.pi * (-0.25 * r0h_3 * i[1] + b3 / r03 * i[0] + d3)
 
 
 @njit
 def get_I_terms(cosp, a2, a):
+    """Calculate I constants for calculations in _full_integral_3d"""
     cosp2 = cosp * cosp
     p = math.acos(cosp)
     tamath = math.sqrt(1. - cosp2) / cosp

--- a/sarracen/kernels/cubic_spline_exact.py
+++ b/sarracen/kernels/cubic_spline_exact.py
@@ -4,7 +4,7 @@ from numba import njit
 
 
 @njit
-def pint(r0, d1, d2, h):
+def line_int(r0, d1, d2, h):
     """ Calculate an exact 2D line integral over the cubic spline kernel.
 
     Used in exact calculation of a pixel surface integral in 2D.
@@ -189,7 +189,7 @@ def _f3_2d(phi):
 
 
 @njit
-def wallint(r0, x1, y1, x2, y2, wx, wy, h):
+def surface_int(r0, x1, y1, x2, y2, wx, wy, h):
     """ Calculate an exact 3D surface integral over the cubic spline kernel.
 
     Used to exactly calculating the contribution of a particle to a pixel's volume in 3D space.
@@ -219,31 +219,31 @@ def wallint(r0, x1, y1, x2, y2, wx, wy, h):
     r1 = 0.5 * wy + dy
     d1 = 0.5 * wx - dx
     d2 = 0.5 * wx + dx
-    result = result + _pint3d(r0, r1, d1, d2, h)
+    result = result + _line_int3d(r0, r1, d1, d2, h)
 
     # Top boundary
     r1 = 0.5 * wy - dy
     d1 = 0.5 * wx + dx
     d2 = 0.5 * wx - dx
-    result = result + _pint3d(r0, r1, d1, d2, h)
+    result = result + _line_int3d(r0, r1, d1, d2, h)
 
     # Right boundary
     r1 = 0.5 * wx + dx
     d1 = 0.5 * wy + dy
     d2 = 0.5 * wy - dy
-    result = result + _pint3d(r0, r1, d1, d2, h)
+    result = result + _line_int3d(r0, r1, d1, d2, h)
 
     # Left boundary
     r1 = 0.5 * wx - dx
     d1 = 0.5 * wy - dy
     d2 = 0.5 * wy + dy
-    result = result + _pint3d(r0, r1, d1, d2, h)
+    result = result + _line_int3d(r0, r1, d1, d2, h)
 
     return result
 
 
 @njit
-def _pint3d(r0, r1, d1, d2, h):
+def _line_int3d(r0, r1, d1, d2, h):
     """ Calculate an exact 3D line integral over the cubic spline kernel.
 
     Used in wallint.

--- a/sarracen/kernels/cubic_spline_exact.py
+++ b/sarracen/kernels/cubic_spline_exact.py
@@ -87,10 +87,177 @@ def F2_2d(phi, q0):
     I5 = 1. / 16. * (0.5 * (11. * np.sin(phi) + 3. * np.sin(3. * phi)) / cphi2 / cphi2 + 6. * logs)
 
     return 5. / 7. * q02 / np.pi * (
-                2. * I2 - 2. * q0 * I3 + 3. / 4. * q02 * I4 - 1. / 10. * q03 * I5 - 1. / 10. / q02 * I0)
+            2. * I2 - 2. * q0 * I3 + 3. / 4. * q02 * I4 - 1. / 10. * q03 * I5 - 1. / 10. / q02 * I0)
 
 
 @njit
 def F3_2d(phi):
     I0 = phi
     return 0.5 / np.pi * I0
+
+
+@njit
+def wallint(r0, xp, yp, xc, yc, pixwidthx, pixwidthy, hi):
+    result = 0.0
+    dx = xc - xp
+    dy = yc - yp
+    h = hi
+
+    R_0 = 0.5 * pixwidthy + dy
+    d1 = 0.5 * pixwidthx - dx
+    d2 = 0.5 * pixwidthx + dx
+    result = result + pint3D(r0, R_0, d1, d2, h)
+
+    R_0 = 0.5 * pixwidthy - dy
+    d1 = 0.5 * pixwidthx + dx
+    d2 = 0.5 * pixwidthx - dx
+    result = result + pint3D(r0, R_0, d1, d2, h)
+
+    R_0 = 0.5 * pixwidthx + dx
+    d1 = 0.5 * pixwidthy + dy
+    d2 = 0.5 * pixwidthy - dy
+    result = result + pint3D(r0, R_0, d1, d2, h)
+
+    R_0 = 0.5 * pixwidthx - dx
+    d1 = 0.5 * pixwidthy - dy
+    d2 = 0.5 * pixwidthy + dy
+    result = result + pint3D(r0, R_0, d1, d2, h)
+
+    return result
+
+
+@njit
+def pint3D(r0, R_0, d1, d2, hi):
+    if abs(r0) == 0:
+        return 0
+
+    if r0 > 0.:
+        result = 1
+        ar0 = r0
+    else:
+        result = -1
+        ar0 = -r0
+
+    if R_0 > 0.:
+        aR_0 = R_0
+    else:
+        result = -result
+        aR_0 = -R_0
+
+    int1 = full_integral_3D(d1, ar0, aR_0, hi)
+    int2 = full_integral_3D(d2, ar0, aR_0, hi)
+
+    if int1 < 0:
+        int1 = 0
+    if int2 < 0:
+        int2 = 0
+
+    if d1 * d2 >= 0:
+        result = result * (int1 + int2)
+        if int1 + int2 < 0:
+            print('Error: int1 + int2 < 0')
+    elif abs(d1) < abs(d2):
+        result = result * (int2 - int1)
+        if int2 - int1 < 0:
+            print('Error: int2 - int1 < 0: ', int1, int2, '(', d1, d2, ')')
+    else:
+        result = result * (int1 - int2)
+        if int1 - int2 < 0:
+            print('Error: int1 - int2 < 0: ', int1, int2, '(', d1, d2, ')')
+
+    return result
+
+
+@njit
+def full_integral_3D(d, r0, R_0, h):
+    r0h = r0 / h
+    tanphi = abs(d) / R_0
+    phi = np.arctan(tanphi)
+
+    if abs(r0h) == 0 or abs(R_0 / h) == 0 or abs(phi) == 0:
+        return 0
+
+    h2 = h * h
+    r03 = r0 * r0 * r0
+    r0h2 = r0h * r0h
+    r0h3 = r0h2 * r0h
+    r0h_2 = 1. / r0h2
+    r0h_3 = 1. / r0h3
+
+    B1 = None
+    B2 = None
+    if r0 > 2.0 * h:
+        B3 = 0.25 * h2 * h
+    elif r0 > h:
+        B3 = 0.25 * r03 * (-4. / 3. + (r0h) - 0.3 * r0h2 + 1. / 30. * r0h3 - 1. / 15. * r0h_3 + 8. / 5. * r0h_2)
+        B2 = 0.25 * r03 * (-4. / 3. + (r0h) - 0.3 * r0h2 + 1. / 30. * r0h3 - 1. / 15. * r0h_3)
+    else:
+        B3 = 0.25 * r03 * (-2. / 3. + 0.3 * r0h2 - 0.1 * r0h3 + 7. / 5. * r0h_2)
+        B2 = 0.25 * r03 * (-2. / 3. + 0.3 * r0h2 - 0.1 * r0h3 - 1. / 5. * r0h_2)
+        B1 = 0.25 * r03 * (-2. / 3. + 0.3 * r0h2 - 0.1 * r0h3)
+
+    a = R_0 / r0
+    a2 = a * a
+
+    linedist2 = (r0 * r0 + R_0 * R_0)
+    cosphi = np.cos(phi)
+    R_ = R_0 / cosphi
+    r2 = (r0 * r0 + R_ * R_)
+
+    D2 = 0.0
+    D3 = 0.0
+
+    if linedist2 < h2:
+        cosp = R_0 / np.sqrt(h2 - r0 * r0)
+        I0, I1, I_2, I_3, I_4, I_5 = get_I_terms(cosp, a2, a)
+
+        D2 = -1. / 6. * I_2 + 0.25 * (r0h) * I_3 - 0.15 * r0h2 * I_4 + 1. / 30. * r0h3 * I_5 - 1. / 60. * r0h_3 * I1 + (
+                B1 - B2) / r03 * I0
+    if linedist2 < 4. * h2:
+        cosp = R_0 / np.sqrt(4.0 * h2 - r0 * r0)
+        I0, I1, I_2, I_3, I_4, I_5 = get_I_terms(cosp, a2, a)
+
+        if B2 is None:
+            print("Ouch!")
+
+        D3 = 1. / 3. * I_2 - 0.25 * (
+            r0h) * I_3 + 3. / 40. * r0h2 * I_4 - 1. / 120. * r0h3 * I_5 + 4. / 15. * r0h_3 * I1 + (
+                     B2 - B3) / r03 * I0 + D2
+
+    I0, I1, I_2, I_3, I_4, I_5 = get_I_terms(cosphi, a2, a, phi=phi, tanphi=tanphi)
+
+    if r2 <= h2:
+        return r0h3 / np.pi * (1. / 6. * I_2 - 3. / 40. * r0h2 * I_4 + 1. / 40. * r0h3 * I_5 + B1 / r03 * I0)
+    elif r2 <= 4. * h2:
+        return r0h3 / np.pi * (0.25 * (4. / 3. * I_2 - (
+                r0 / h) * I_3 + 0.3 * r0h2 * I_4 - 1. / 30. * r0h3 * I_5 + 1. / 15. * r0h_3 * I1) + B2 / r03 * I0 + D2)
+    else:
+        return r0h3 / np.pi * (-0.25 * r0h_3 * I1 + B3 / r03 * I0 + D3)
+
+
+@njit
+def get_I_terms(cosp, a2, a, phi=None, tanphi=None):
+    cosp2 = cosp * cosp
+    if phi:
+        p = phi
+        tanp = tanphi
+    else:
+        p = np.arccos(cosp)
+        tanp = np.sqrt(1. - cosp2) / cosp
+
+    mu2_1 = 1. / (1. + cosp2 / a2)
+    I0 = p
+    I_2 = p + a2 * tanp
+    I_4 = p + 2. * a2 * tanp + 1. / 3. * a2 * a2 * tanp * (2. + 1. / cosp2)
+
+    u2 = (1. - cosp2) * mu2_1
+    u = np.sqrt(u2)
+    logs = np.log((1. + u) / (1. - u))
+    I1 = np.arctan2(u, a)
+
+    fac = 1. / (1. - u2)
+    I_1 = 0.5 * a * logs + I1
+    I_3 = I_1 + a * 0.25 * (1. + a2) * (2. * u * fac + logs)
+    I_5 = I_3 + a * (1. + a2) * (1. + a2) / 16. * ((10. * u - 6. * u * u2) * fac * fac + 3. * logs)
+
+    return I0, I1, I_2, I_3, I_4, I_5

--- a/sarracen/kernels/cubic_spline_exact.py
+++ b/sarracen/kernels/cubic_spline_exact.py
@@ -1,0 +1,96 @@
+import numpy as np
+from numba import njit
+
+
+@njit
+def pint(r0, d1, d2, hi1):
+    if r0 == 0:
+        return 0
+    elif r0 > 0:
+        result = 1
+        ar0 = r0
+    else:
+        result = -1
+        ar0 = -r0
+
+    q0 = ar0 * hi1
+    phi1 = np.arctan(abs(d1) / ar0)
+    phi2 = np.arctan(abs(d2) / ar0)
+
+    if d1 * d2 >= 0:
+        result = result * (full_2d_mod(phi1, q0) + full_2d_mod(phi2, q0))
+    elif abs(d1) < abs(d2):
+        result = result * (full_2d_mod(phi2, q0) - full_2d_mod(phi1, q0))
+    else:
+        result = result * (full_2d_mod(phi1, q0) - full_2d_mod(phi2, q0))
+
+    return result
+
+
+@njit
+def full_2d_mod(phi, q0):
+    if q0 <= 1.0:
+        cphi = np.cos(phi)
+        q = q0 / cphi
+
+        if q <= 1.0:
+            return F1_2d(phi, q0)
+        elif q <= 2.0:
+            phi1 = np.arccos(q0)
+            return F2_2d(phi, q0) - F2_2d(phi1, q0) + F1_2d(phi1, q0)
+        else:
+            phi1 = np.arccos(q0)
+            phi2 = np.arccos(0.5 * q0)
+            return F3_2d(phi) - F3_2d(phi2) + F2_2d(phi2, q0) - F2_2d(phi1, q0) + F1_2d(
+                phi1, q0)
+    elif q0 <= 2.0:
+        cphi = np.cos(phi)
+        q = q0 / cphi
+
+        if q <= 2.0:
+            return F2_2d(phi, q0)
+        else:
+            phi2 = np.arccos(0.5 * q0)
+            return F3_2d(phi) - F3_2d(phi2) + F2_2d(phi2, q0)
+    else:
+        return F3_2d(phi)
+
+
+@njit
+def F1_2d(phi, q0):
+    cphi2 = np.cos(phi) ** 2
+
+    logs = np.log(np.tan(phi / 2. + np.pi / 4.))
+
+    I2 = np.tan(phi)
+    I4 = 1. / 3. * np.tan(phi) * (2. + 1. / cphi2)
+
+    I5 = 1. / 16. * (0.5 * (11. * np.sin(phi) + 3. * np.sin(3. * phi)) / cphi2 / cphi2 + 6. * logs)
+
+    return 5. / 7. * q0 ** 2 / np.pi * (I2 - 3. / 4. * q0 ** 2 * I4 + 0.3 * q0 ** 3 * I5)
+
+
+@njit
+def F2_2d(phi, q0):
+    cphi2 = np.cos(phi) ** 2
+
+    q02 = q0 * q0
+    q03 = q02 * q0
+
+    logs = np.log(np.tan(phi / 2. + np.pi / 4.))
+
+    I0 = phi
+    I2 = np.tan(phi)
+    I4 = 1. / 3. * np.tan(phi) * (2. + 1. / cphi2)
+
+    I3 = 1. / 2. * (np.tan(phi) / np.cos(phi) + logs)
+    I5 = 1. / 16. * (0.5 * (11. * np.sin(phi) + 3. * np.sin(3. * phi)) / cphi2 / cphi2 + 6. * logs)
+
+    return 5. / 7. * q02 / np.pi * (
+                2. * I2 - 2. * q0 * I3 + 3. / 4. * q02 * I4 - 1. / 10. * q03 * I5 - 1. / 10. / q02 * I0)
+
+
+@njit
+def F3_2d(phi):
+    I0 = phi
+    return 0.5 / np.pi * I0

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -470,11 +470,12 @@ def render_2d_cross(data: 'SarracenDataFrame', target: str, x: str = None, y: st
     return ax
 
 
-def render_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None, kernel: BaseKernel = None,
-              integral_samples: int = 1000, rotation: np.ndarray = None, rot_origin: np.ndarray = None,
-              x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
-              y_max: float = None, cmap: Union[str, Colormap] = 'RdBu', cbar: bool = True, cbar_kws: dict = {},
-              cbar_ax: Axes = None, ax: Axes = None, backend: str = None, **kwargs) -> Axes:
+def render_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None, z: str = None,
+              kernel: BaseKernel = None, integral_samples: int = 1000, rotation: np.ndarray = None,
+              rot_origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None, x_min: float = None,
+              x_max: float = None, y_min: float = None, y_max: float = None, cmap: Union[str, Colormap] = 'RdBu',
+              cbar: bool = True, cbar_kws: dict = {}, cbar_ax: Axes = None, ax: Axes = None, exact: bool = None,
+              backend: str = None, **kwargs) -> Axes:
     """ Render 3D particle data to a 2D grid, using SPH column rendering of a target variable.
 
     Render the data within a SarracenDataFrame to a 2D matplotlib object, by rendering the values
@@ -535,8 +536,8 @@ def render_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = No
         If `target`, `x`, `y`, mass, density, or smoothing length columns do not
         exist in `data`.
     """
-    image = interpolate_3d(data, target, x, y, kernel, integral_samples, rotation, rot_origin, x_pixels, y_pixels, x_min,
-                           x_max, y_min, y_max, backend)
+    image = interpolate_3d(data, target, x, y, z, kernel, integral_samples, rotation, rot_origin, x_pixels, y_pixels,
+                           x_min, x_max, y_min, y_max, exact, backend)
 
     if ax is None:
         ax = plt.gca()

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -122,7 +122,7 @@ def _set_pixels(x_pixels, y_pixels, x_min, x_max, y_min, y_max, default):
 def render_2d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None, kernel: BaseKernel = None,
               x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
               y_max: float = None, cmap: Union[str, Colormap] = 'RdBu', cbar: bool = True, cbar_kws: dict = {},
-              cbar_ax: Axes = None, ax: Axes = None, backend: str = None, **kwargs) -> Axes:
+              cbar_ax: Axes = None, ax: Axes = None, exact: bool = False, backend: str = None, **kwargs) -> Axes:
     """ Render 2D particle data to a 2D grid, using SPH rendering of a target variable.
 
     Render the data within a SarracenDataFrame to a 2D matplotlib object, by rendering the values
@@ -155,6 +155,8 @@ def render_2d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = No
         Axes to draw the colorbar in, if not provided then space will be taken from the main Axes.
     ax: Axes
         The main axes in which to draw the rendered image.
+    exact: bool
+        Whether to use exact interpolation of the data.
     backend: ['cpu', 'gpu']
         The computation backend to use when rendering this data. Defaults to the backend specified in `data`.
     kwargs: other keyword arguments
@@ -174,7 +176,7 @@ def render_2d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = No
         If `target`, `x`, `y`, mass, density, or smoothing length columns do not
         exist in `data`.
     """
-    image = interpolate_2d(data, target, x, y, kernel, x_pixels, y_pixels, x_min, x_max, y_min, y_max, backend)
+    image = interpolate_2d(data, target, x, y, kernel, x_pixels, y_pixels, x_min, x_max, y_min, y_max, exact, backend)
 
     if ax is None:
         ax = plt.gca()

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -122,7 +122,7 @@ def _set_pixels(x_pixels, y_pixels, x_min, x_max, y_min, y_max, default):
 def render_2d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None, kernel: BaseKernel = None,
               x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
               y_max: float = None, cmap: Union[str, Colormap] = 'RdBu', cbar: bool = True, cbar_kws: dict = {},
-              cbar_ax: Axes = None, ax: Axes = None, exact: bool = False, backend: str = None, **kwargs) -> Axes:
+              cbar_ax: Axes = None, ax: Axes = None, exact: bool = None, backend: str = None, **kwargs) -> Axes:
     """ Render 2D particle data to a 2D grid, using SPH rendering of a target variable.
 
     Render the data within a SarracenDataFrame to a 2D matplotlib object, by rendering the values
@@ -156,7 +156,7 @@ def render_2d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = No
     ax: Axes
         The main axes in which to draw the rendered image.
     exact: bool
-        Whether to use exact interpolation of the data.
+        Whether to use exact interpolation of the data. Defaults to False.
     backend: ['cpu', 'gpu']
         The computation backend to use when rendering this data. Defaults to the backend specified in `data`.
     kwargs: other keyword arguments
@@ -238,7 +238,7 @@ def streamlines(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[
     ax: Axes
         The main axes in which to draw the rendered image.
     exact: bool
-        Whether to use exact interpolation of the data. For cross-sections this is ignored.
+        Whether to use exact interpolation of the data. For cross-sections this is ignored. Defaults to False.
     backend: ['cpu', 'gpu']
         The computation backend to use when rendering this data. Defaults to the backend specified in `data`.
     kwargs: other keyword arguments
@@ -265,13 +265,13 @@ def streamlines(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[
         if not len(target) == 2:
             raise ValueError('Target vector is not 2-dimensional.')
         img = interpolate_2d_vec(data, target[0], target[1], x, y, kernel, x_pixels, y_pixels, x_min, x_max, y_min,
-                                 y_max, backend)
+                                 y_max, exact, backend)
     elif data.get_dim() == 3:
         if not len(target) == 3:
             raise ValueError('Target vector is not 3-dimensional.')
         if z_slice is None:
             img = interpolate_3d_vec(data, target[0], target[1], target[2], x, y, kernel, integral_samples, rotation,
-                                     origin, x_pixels, y_pixels, x_min, x_max, y_min, y_max, backend)
+                                     origin, x_pixels, y_pixels, x_min, x_max, y_min, y_max, exact, backend)
         else:
             img = interpolate_3d_cross_vec(data, target[0], target[1], target[2], z_slice, x, y, z, kernel, rotation,
                                            origin, x_pixels, y_pixels, x_min, x_max, y_min, y_max, backend)
@@ -343,7 +343,7 @@ def arrowplot(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[st
     ax: Axes
         The main axes in which to draw the rendered image.
     exact: bool
-        Whether to use exact interpolation of the data. For cross-sections this is ignored.
+        Whether to use exact interpolation of the data. For cross-sections this is ignored. Defaults to False.
     backend: ['cpu', 'gpu']
         The computation backend to use when rendering this data. Defaults to the backend specified in `data`.
     kwargs: other keyword arguments
@@ -523,7 +523,7 @@ def render_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = No
     ax: Axes
         The main axes in which to draw the rendered image.
     exact: bool
-        Whether to use exact interpolation of the data.
+        Whether to use exact interpolation of the data. Defaults to False.
     backend: ['cpu', 'gpu']
         The computation backend to use when rendering this data. Defaults to the backend specified in `data`.
     kwargs: other keyword arguments

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -201,7 +201,7 @@ def streamlines(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[
                 x: str = None, y: str = None, z: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
                 rotation: np.ndarray = None, origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None,
                 x_min: float = None, x_max: float = None, y_min: float = None, y_max: float = None, ax: Axes = None,
-                backend: str = None, **kwargs) -> Axes:
+                exact: bool = None, backend: str = None, **kwargs) -> Axes:
     """ Create an SPH interpolated streamline plot of a target vector.
 
     Render the data within a SarracenDataFrame to a 2D matplotlib object, by rendering the values
@@ -237,6 +237,8 @@ def streamlines(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[
         to the minimum and maximum values of `x` and `y`.
     ax: Axes
         The main axes in which to draw the rendered image.
+    exact: bool
+        Whether to use exact interpolation of the data. For cross-sections this is ignored.
     backend: ['cpu', 'gpu']
         The computation backend to use when rendering this data. Defaults to the backend specified in `data`.
     kwargs: other keyword arguments
@@ -305,7 +307,7 @@ def arrowplot(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[st
               x: str = None, y: str = None, z: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
               rotation: np.ndarray = None, origin: np.ndarray = None, x_arrows: int = None, y_arrows: int = None,
               x_min: float = None, x_max: float = None, y_min: float = None, y_max: float = None, ax: Axes = None,
-              backend: str = None, **kwargs) -> Axes:
+              exact: bool = None, backend: str = None, **kwargs) -> Axes:
     """ Create an SPH interpolated vector field plot of a target vector.
 
     Render the data within a SarracenDataFrame to a 2D matplotlib object, by rendering the values
@@ -340,6 +342,8 @@ def arrowplot(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[st
         to the minimum and maximum values of `x` and `y`.
     ax: Axes
         The main axes in which to draw the rendered image.
+    exact: bool
+        Whether to use exact interpolation of the data. For cross-sections this is ignored.
     backend: ['cpu', 'gpu']
         The computation backend to use when rendering this data. Defaults to the backend specified in `data`.
     kwargs: other keyword arguments
@@ -369,14 +373,17 @@ def arrowplot(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[st
         if not len(target) == 2:
             raise ValueError('Target vector is not 2-dimensional.')
         img = interpolate_2d_vec(data, target[0], target[1], x, y, kernel, x_arrows, y_arrows, x_min, x_max, y_min,
-                                 y_max, backend)
+                                 y_max, exact, backend)
     elif data.get_dim() == 3:
         if not len(target) == 3:
             raise ValueError('Target vector is not 3-dimensional.')
         if z_slice is None:
             img = interpolate_3d_vec(data, target[0], target[1], target[2], x, y, kernel, integral_samples, rotation,
-                                     origin, x_arrows, y_arrows, x_min, x_max, y_min, y_max, backend)
+                                     origin, x_arrows, y_arrows, x_min, x_max, y_min, y_max, exact, backend)
         else:
+            if exact:
+                raise UserWarning("Exact interpolation is not supported for 3D cross-sections.")
+
             img = interpolate_3d_cross_vec(data, target[0], target[1], target[2], z_slice, x, y, z, kernel, rotation,
                                            origin, x_arrows, y_arrows, x_min, x_max, y_min, y_max, backend)
     else:
@@ -470,12 +477,11 @@ def render_2d_cross(data: 'SarracenDataFrame', target: str, x: str = None, y: st
     return ax
 
 
-def render_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None, z: str = None,
-              kernel: BaseKernel = None, integral_samples: int = 1000, rotation: np.ndarray = None,
-              rot_origin: np.ndarray = None, x_pixels: int = None, y_pixels: int = None, x_min: float = None,
-              x_max: float = None, y_min: float = None, y_max: float = None, cmap: Union[str, Colormap] = 'RdBu',
-              cbar: bool = True, cbar_kws: dict = {}, cbar_ax: Axes = None, ax: Axes = None, exact: bool = None,
-              backend: str = None, **kwargs) -> Axes:
+def render_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None, kernel: BaseKernel = None,
+              integral_samples: int = 1000, rotation: np.ndarray = None, rot_origin: np.ndarray = None,
+              x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
+              y_max: float = None, cmap: Union[str, Colormap] = 'RdBu', cbar: bool = True, cbar_kws: dict = {},
+              cbar_ax: Axes = None, ax: Axes = None, exact: bool = None, backend: str = None, **kwargs) -> Axes:
     """ Render 3D particle data to a 2D grid, using SPH column rendering of a target variable.
 
     Render the data within a SarracenDataFrame to a 2D matplotlib object, by rendering the values
@@ -516,6 +522,8 @@ def render_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = No
         Axes to draw the colorbar in, if not provided then space will be taken from the main Axes.
     ax: Axes
         The main axes in which to draw the rendered image.
+    exact: bool
+        Whether to use exact interpolation of the data.
     backend: ['cpu', 'gpu']
         The computation backend to use when rendering this data. Defaults to the backend specified in `data`.
     kwargs: other keyword arguments
@@ -536,7 +544,7 @@ def render_3d(data: 'SarracenDataFrame', target: str, x: str = None, y: str = No
         If `target`, `x`, `y`, mass, density, or smoothing length columns do not
         exist in `data`.
     """
-    image = interpolate_3d(data, target, x, y, z, kernel, integral_samples, rotation, rot_origin, x_pixels, y_pixels,
+    image = interpolate_3d(data, target, x, y, kernel, integral_samples, rotation, rot_origin, x_pixels, y_pixels,
                            x_min, x_max, y_min, y_max, exact, backend)
 
     if ax is None:

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -166,14 +166,15 @@ class SarracenDataFrame(DataFrame):
         return render_2d_cross(self, target, x, y, kernel, pixels, x1, x2, y1, y2, ax, backend, **kwargs)
 
     @_copy_doc(render_3d)
-    def render_3d(self, target: str, x: str = None, y: str = None, kernel: BaseKernel = None, int_samples: int = 1000,
-                  rotation: np.ndarray = None, rot_origin: np.ndarray = None, x_pixels: int = None,
-                  y_pixels: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
-                  y_max: float = None, cmap: Union[str, Colormap] = 'RdBu', cbar: bool = True, cbar_kws: dict = {},
-                  cbar_ax: Axes = None, ax: Axes = None, backend: str = None, **kwargs) -> Axes:
+    def render_3d(self, target: str, x: str = None, y: str = None, z: str = None, kernel: BaseKernel = None,
+                  int_samples: int = 1000, rotation: np.ndarray = None, rot_origin: np.ndarray = None,
+                  x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None,
+                  y_min: float = None, y_max: float = None, cmap: Union[str, Colormap] = 'RdBu', cbar: bool = True,
+                  cbar_kws: dict = {}, cbar_ax: Axes = None, ax: Axes = None, exact: bool = None, backend: str = None,
+                  **kwargs) -> Axes:
 
-        return render_3d(self, target, x, y, kernel, int_samples, rotation, rot_origin, x_pixels, y_pixels, x_min, x_max,
-                         y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, backend, **kwargs)
+        return render_3d(self, target, x, y, z, kernel, int_samples, rotation, rot_origin, x_pixels, y_pixels, x_min,
+                         x_max, y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, exact, backend, **kwargs)
 
     @_copy_doc(render_3d_cross)
     def render_3d_cross(self, target: str, z_slice: float = None, x: str = None, y: str = None, z: str = None,

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -153,10 +153,10 @@ class SarracenDataFrame(DataFrame):
     def render_2d(self, target: str, x: str = None, y: str = None, kernel: BaseKernel = None, x_pixels: int = None,
                   y_pixels: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
                   y_max: float = None, cmap: Union[str, Colormap] = 'RdBu', cbar: bool = True, cbar_kws: dict = {},
-                  cbar_ax: Axes = None, ax: Axes = None, backend: str = None, **kwargs) -> Axes:
+                  cbar_ax: Axes = None, ax: Axes = None, exact: bool = None, backend: str = None, **kwargs) -> Axes:
 
         return render_2d(self, target, x, y, kernel, x_pixels, y_pixels, x_min, x_max, y_min, y_max, cmap, cbar,
-                         cbar_kws, cbar_ax, ax, backend, **kwargs)
+                         cbar_kws, cbar_ax, ax, exact, backend, **kwargs)
 
     @_copy_doc(render_2d_cross)
     def render_2d_cross(self, target: str, x: str = None, y: str = None, kernel: BaseKernel = None, pixels: int = 512,

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -166,14 +166,14 @@ class SarracenDataFrame(DataFrame):
         return render_2d_cross(self, target, x, y, kernel, pixels, x1, x2, y1, y2, ax, backend, **kwargs)
 
     @_copy_doc(render_3d)
-    def render_3d(self, target: str, x: str = None, y: str = None, z: str = None, kernel: BaseKernel = None,
+    def render_3d(self, target: str, x: str = None, y: str = None, kernel: BaseKernel = None,
                   int_samples: int = 1000, rotation: np.ndarray = None, rot_origin: np.ndarray = None,
                   x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None,
                   y_min: float = None, y_max: float = None, cmap: Union[str, Colormap] = 'RdBu', cbar: bool = True,
                   cbar_kws: dict = {}, cbar_ax: Axes = None, ax: Axes = None, exact: bool = None, backend: str = None,
                   **kwargs) -> Axes:
 
-        return render_3d(self, target, x, y, z, kernel, int_samples, rotation, rot_origin, x_pixels, y_pixels, x_min,
+        return render_3d(self, target, x, y, kernel, int_samples, rotation, rot_origin, x_pixels, y_pixels, x_min,
                          x_max, y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, exact, backend, **kwargs)
 
     @_copy_doc(render_3d_cross)
@@ -192,18 +192,18 @@ class SarracenDataFrame(DataFrame):
                     y: str = None, z: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
                     rotation: np.ndarray = None, rot_origin: np.ndarray = None, x_pixels: int = None,
                     y_pixels: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
-                    y_max: float = None, ax: Axes = None, backend: str='cpu', **kwargs) -> Axes:
+                    y_max: float = None, ax: Axes = None, exact: bool = None, backend: str='cpu', **kwargs) -> Axes:
         return streamlines(self, target, z_slice, x, y, z, kernel, integral_samples, rotation, rot_origin, x_pixels,
-                           y_pixels, x_min, x_max, y_min, y_max, ax, backend, **kwargs)
+                           y_pixels, x_min, x_max, y_min, y_max, ax, exact, backend, **kwargs)
 
     @_copy_doc(arrowplot)
     def arrowplot(self, target: Union[Tuple[str, str], Tuple[str, str, str]], z_slice: int = None, x: str = None,
                   y: str = None, z: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
                   rotation: np.ndarray = None, rot_origin: np.ndarray = None, x_arrows: int = None,
                   y_arrows: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
-                  y_max: float = None, ax: Axes = None, backend: str='cpu', **kwargs) -> Axes:
+                  y_max: float = None, ax: Axes = None, exact: bool = None, backend: str='cpu', **kwargs) -> Axes:
         return arrowplot(self, target, z_slice, x, y, z, kernel, integral_samples, rotation, rot_origin, x_arrows,
-                         y_arrows, x_min, x_max, y_min, y_max, ax, backend, **kwargs)
+                         y_arrows, x_min, x_max, y_min, y_max, ax, exact, backend, **kwargs)
 
     @property
     def params(self):

--- a/sarracen/tests/test_interpolate.py
+++ b/sarracen/tests/test_interpolate.py
@@ -1058,14 +1058,21 @@ def test_exact_interpolation(backend):
     """
     Exact interpolation over the entire effective area of a kernel should return 1 over the particle bounds, multiplied by the weight.
     """
-    df = pd.DataFrame({'x': [0], 'y': [0], 'A': [2], 'h': [1.1], 'rho': [0.55], 'm': [0.04]})
-    sdf = SarracenDataFrame(df, params=dict())
-    sdf.backend = backend
+    df_2 = pd.DataFrame({'x': [0], 'y': [0], 'A': [2], 'h': [1.1], 'rho': [0.55], 'm': [0.04]})
+    sdf_2 = SarracenDataFrame(df_2, params=dict())
+    sdf_2.backend = backend
+    df_3 = pd.DataFrame({'x': [0], 'y': [0], 'z': [1], 'A': [2], 'h': [1.1], 'rho': [0.55], 'm': [0.04]})
+    sdf_3 = SarracenDataFrame(df_3, params=dict())
+    sdf_3.backend = backend
 
     kernel = CubicSplineKernel()
-    w = sdf['m'] * sdf['A'] / (sdf['rho'] * sdf['h'] ** 2)
+    w = sdf_2['m'] * sdf_2['A'] / (sdf_2['rho'] * sdf_2['h'] ** 2)
 
-    bound = kernel.get_radius() * sdf['h'][0]
-    image = interpolate_2d(sdf, 'A', x_min=-bound, x_max=bound, y_min=-bound, y_max=bound, x_pixels=1, exact=True)
+    bound = kernel.get_radius() * sdf_2['h'][0]
+    image = interpolate_2d(sdf_2, 'A', x_min=-bound, x_max=bound, y_min=-bound, y_max=bound, x_pixels=1, exact=True)
 
-    assert image.sum() == approx(w[0] * sdf['h'][0] ** 2 / (4 * bound ** 2))
+    assert image.sum() == approx(w[0] * sdf_2['h'][0] ** 2 / (4 * bound ** 2))
+
+    image = interpolate_3d(sdf_3, 'A', x_min=-bound, x_max=bound, y_min=-bound, y_max=bound, x_pixels=1, exact=True)
+
+    assert image.sum() == approx(w[0] * sdf_2['h'][0] ** 2 / (4 * bound ** 2))


### PR DESCRIPTION
Implements exact SPH interpolation using an analytic solution for volume & surface integrals for the cubic spline kernels, with a similar implementation to Splash, by Maya Petkova and Daniel Price.

This type of interpolation can be performed for 2D scalar and vector interpolation, and for 3D scalar and vector projective interpolation. There is currently no support for 2D or 3D cross-sections.

Example:
![image](https://user-images.githubusercontent.com/71343838/179303374-168dd06a-1f64-4b3f-8cf9-bd159b4f8b31.png)
