### PR TITLE
Merge scalar rendering functions into one function

### DIFF
--- a/sarracen/__init__.py
+++ b/sarracen/__init__.py
@@ -6,4 +6,4 @@ from sarracen.readers.read_phantom import read_phantom
 from sarracen.sarracen_dataframe import SarracenDataFrame
 
 from sarracen.interpolate import interpolate_2d, interpolate_2d_cross, interpolate_3d, interpolate_3d_cross
-from sarracen.render import render_2d, render_2d_cross, render_3d, render_3d_cross
+from sarracen.render import render, streamlines, arrowplot

--- a/sarracen/__init__.py
+++ b/sarracen/__init__.py
@@ -5,5 +5,5 @@ from sarracen.readers.read_phantom import read_phantom
 
 from sarracen.sarracen_dataframe import SarracenDataFrame
 
-from sarracen.interpolate import interpolate_2d, interpolate_2d_cross, interpolate_3d, interpolate_3d_cross
+from sarracen.interpolate import interpolate_2d, interpolate_2d_line, interpolate_3d, interpolate_3d_cross
 from sarracen.render import render, streamlines, arrowplot

--- a/sarracen/interpolate/__init__.py
+++ b/sarracen/interpolate/__init__.py
@@ -1,5 +1,5 @@
 from sarracen.interpolate.base_backend import BaseBackend
 from sarracen.interpolate.cpu_backend import CPUBackend
 from sarracen.interpolate.gpu_backend import GPUBackend
-from sarracen.interpolate.interpolate import interpolate_2d_cross, interpolate_2d, interpolate_3d,\
+from sarracen.interpolate.interpolate import interpolate_2d_line, interpolate_2d, interpolate_3d,\
     interpolate_3d_cross, interpolate_3d_vec, interpolate_3d_cross_vec, interpolate_2d_vec

--- a/sarracen/interpolate/base_backend.py
+++ b/sarracen/interpolate/base_backend.py
@@ -47,7 +47,7 @@ class BaseBackend:
 
 
     @staticmethod
-    def interpolate_3d_cross(target: ndarray, z_slice: float, x: ndarray, y: ndarray, z: ndarray, mass: ndarray,
+    def interpolate_3d_cross(target: ndarray, x: ndarray, y: ndarray, z: ndarray, z_slice: float, mass: ndarray,
                              rho: ndarray, h: ndarray, weight_function: CPUDispatcher, kernel_radius: float,
                              x_pixels: int, y_pixels: int, x_min: float, x_max: float, y_min: float,
                              y_max: float) -> ndarray:
@@ -58,10 +58,10 @@ class BaseBackend:
 
 
     @staticmethod
-    def interpolate_3d_cross_vec(target_x: ndarray, target_y: ndarray, z_slice: float, x: ndarray, y: ndarray,
-                                 z: ndarray, mass: ndarray, rho: ndarray, h: ndarray, weight_function: CPUDispatcher,
-                                 kernel_radius: float, x_pixels: int, y_pixels: int, x_min: float, x_max: float,
-                                 y_min: float, y_max: float) -> Tuple[ndarray, ndarray]:
+    def interpolate_3d_cross_vec(target_x: ndarray, target_y: ndarray, x: ndarray, y: ndarray, z: ndarray,
+                                 z_slice: float, mass: ndarray, rho: ndarray, h: ndarray,
+                                 weight_function: CPUDispatcher, kernel_radius: float, x_pixels: int, y_pixels: int,
+                                 x_min: float, x_max: float, y_min: float, y_max: float) -> Tuple[ndarray, ndarray]:
         """
         Interpolate 3D particle vector data to a pair of 2D grids of pixels, using a 3D cross-section at a
         specific z value.

--- a/sarracen/interpolate/base_backend.py
+++ b/sarracen/interpolate/base_backend.py
@@ -23,7 +23,7 @@ class BaseBackend:
         return zeros((y_pixels, x_pixels)), zeros((y_pixels, x_pixels))
 
     @staticmethod
-    def interpolate_2d_cross(target: ndarray, x: ndarray, y: ndarray, mass: ndarray, rho: ndarray, h: ndarray,
+    def interpolate_2d_line(target: ndarray, x: ndarray, y: ndarray, mass: ndarray, rho: ndarray, h: ndarray,
                              weight_function: CPUDispatcher, kernel_radius: float, pixels: int, x1: float,
                              x2: float, y1: float, y2: float) -> ndarray:
         """ Interpolate 2D particle data to a 1D cross-sectional line. """

--- a/sarracen/interpolate/cpu_backend.py
+++ b/sarracen/interpolate/cpu_backend.py
@@ -19,7 +19,7 @@ class CPUBackend(BaseBackend):
             return CPUBackend._exact_2d_render(target, x, y, mass, rho, h, x_pixels, y_pixels, x_min, x_max, y_min,
                                                y_max)
         else:
-            return CPUBackend._fast_2d(target, 0, x, y, np.zeros(len(target)), mass, rho, h, weight_function,
+            return CPUBackend._fast_2d(target, x, y, np.zeros(len(target)), 0, mass, rho, h, weight_function,
                                        kernel_radius, x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2)
 
     @staticmethod
@@ -32,10 +32,11 @@ class CPUBackend(BaseBackend):
                                                 y_max),
                     CPUBackend._exact_2d_render(target_y, x, y, mass, rho, h, x_pixels, y_pixels, x_min, x_max, y_min,
                                                 y_max))
-        return (CPUBackend._fast_2d(target_x, 0, x, y, np.zeros(len(target_x)), mass, rho, h, weight_function,
-                                    kernel_radius, x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2),
-                CPUBackend._fast_2d(target_y, 0, x, y, np.zeros(len(target_y)), mass, rho, h, weight_function,
-                                    kernel_radius, x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2))
+        return (
+        CPUBackend._fast_2d(target_x, x, y, np.zeros(len(target_x)), 0, mass, rho, h, weight_function, kernel_radius,
+                            x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2),
+        CPUBackend._fast_2d(target_y, x, y, np.zeros(len(target_y)), 0, mass, rho, h, weight_function, kernel_radius,
+                            x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2))
 
     @staticmethod
     def interpolate_2d_cross(target: ndarray, x: ndarray, y: ndarray, mass: ndarray, rho: ndarray, h: ndarray,
@@ -52,7 +53,7 @@ class CPUBackend(BaseBackend):
         if exact:
             return CPUBackend._exact_3d_project(target, x, y, mass, rho, h, x_pixels, y_pixels, x_min, x_max, y_min,
                                                 y_max)
-        return CPUBackend._fast_2d(target, 0, x, y, np.zeros(len(target)), mass, rho, h, weight_function, kernel_radius,
+        return CPUBackend._fast_2d(target, x, y, np.zeros(len(target)), 0, mass, rho, h, weight_function, kernel_radius,
                                    x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2)
 
     @staticmethod
@@ -65,34 +66,35 @@ class CPUBackend(BaseBackend):
                                                  y_max),
                     CPUBackend._exact_3d_project(target_y, x, y, mass, rho, h, x_pixels, y_pixels, x_min, x_max, y_min,
                                                  y_max))
-        return (CPUBackend._fast_2d(target_x, 0, x, y, np.zeros(len(target_x)), mass, rho, h, weight_function,
-                                    kernel_radius, x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2),
-                CPUBackend._fast_2d(target_y, 0, x, y, np.zeros(len(target_y)), mass, rho, h, weight_function,
-                                    kernel_radius, x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2))
+        return (
+        CPUBackend._fast_2d(target_x, x, y, np.zeros(len(target_x)), 0, mass, rho, h, weight_function, kernel_radius,
+                            x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2),
+        CPUBackend._fast_2d(target_y, x, y, np.zeros(len(target_y)), 0, mass, rho, h, weight_function, kernel_radius,
+                            x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2))
 
     @staticmethod
-    def interpolate_3d_cross(target: ndarray, z_slice: float, x: ndarray, y: ndarray, z: ndarray, mass: ndarray,
+    def interpolate_3d_cross(target: ndarray, x: ndarray, y: ndarray, z: ndarray, z_slice: float, mass: ndarray,
                              rho: ndarray, h: ndarray, weight_function: CPUDispatcher, kernel_radius: float,
                              x_pixels: int, y_pixels: int, x_min: float, x_max: float, y_min: float,
                              y_max: float) -> ndarray:
-        return CPUBackend._fast_2d(target, z_slice, x, y, z, mass, rho, h, weight_function, kernel_radius, x_pixels,
+        return CPUBackend._fast_2d(target, x, y, z, z_slice, mass, rho, h, weight_function, kernel_radius, x_pixels,
                                    y_pixels, x_min, x_max, y_min, y_max, 3)
 
     @staticmethod
-    def interpolate_3d_cross_vec(target_x: ndarray, target_y: ndarray, z_slice: float, x: ndarray, y: ndarray,
-                                 z: ndarray, mass: ndarray, rho: ndarray, h: ndarray, weight_function: CPUDispatcher,
-                                 kernel_radius: float, x_pixels: int, y_pixels: int, x_min: float, x_max: float,
-                                 y_min: float, y_max: float) -> Tuple[ndarray, ndarray]:
-        return (CPUBackend._fast_2d(target_x, z_slice, x, y, z, mass, rho, h, weight_function, kernel_radius, x_pixels,
+    def interpolate_3d_cross_vec(target_x: ndarray, target_y: ndarray, x: ndarray, y: ndarray, z: ndarray,
+                                 z_slice: float, mass: ndarray, rho: ndarray, h: ndarray,
+                                 weight_function: CPUDispatcher, kernel_radius: float, x_pixels: int, y_pixels: int,
+                                 x_min: float, x_max: float, y_min: float, y_max: float) -> Tuple[ndarray, ndarray]:
+        return (CPUBackend._fast_2d(target_x, x, y, z, z_slice, mass, rho, h, weight_function, kernel_radius, x_pixels,
                                     y_pixels, x_min, x_max, y_min, y_max, 3),
-                CPUBackend._fast_2d(target_y, z_slice, x, y, z, mass, rho, h, weight_function, kernel_radius, x_pixels,
+                CPUBackend._fast_2d(target_y, x, y, z, z_slice, mass, rho, h, weight_function, kernel_radius, x_pixels,
                                     y_pixels, x_min, x_max, y_min, y_max, 3))
 
     # Underlying CPU numba-compiled code for interpolation to a 2D grid. Used in interpolation of 2D data,
     # and column integration / cross-sections of 3D data.
     @staticmethod
     @njit(parallel=True, fastmath=True)
-    def _fast_2d(target, z_slice, x_data, y_data, z_data, mass_data, rho_data, h_data, weight_function,
+    def _fast_2d(target, x_data, y_data, z_data, z_slice, mass_data, rho_data, h_data, weight_function,
                  kernel_radius, x_pixels, y_pixels, x_min, x_max, y_min, y_max, n_dims):
         output = np.zeros((y_pixels, x_pixels))
         pixwidthx = (x_max - x_min) / x_pixels

--- a/sarracen/interpolate/cpu_backend.py
+++ b/sarracen/interpolate/cpu_backend.py
@@ -39,9 +39,9 @@ class CPUBackend(BaseBackend):
                             x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2))
 
     @staticmethod
-    def interpolate_2d_cross(target: ndarray, x: ndarray, y: ndarray, mass: ndarray, rho: ndarray, h: ndarray,
-                             weight_function: CPUDispatcher, kernel_radius: float, pixels: int, x1: float, x2: float,
-                             y1: float, y2: float) -> ndarray:
+    def interpolate_2d_line(target: ndarray, x: ndarray, y: ndarray, mass: ndarray, rho: ndarray, h: ndarray,
+                            weight_function: CPUDispatcher, kernel_radius: float, pixels: int, x1: float, x2: float,
+                            y1: float, y2: float) -> ndarray:
         return CPUBackend._fast_2d_cross_cpu(target, x, y, mass, rho, h, weight_function, kernel_radius, pixels, x1, x2,
                                              y1, y2)
 

--- a/sarracen/interpolate/gpu_backend.py
+++ b/sarracen/interpolate/gpu_backend.py
@@ -39,9 +39,9 @@ class GPUBackend(BaseBackend):
                             x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2))
 
     @staticmethod
-    def interpolate_2d_cross(target: ndarray, x: ndarray, y: ndarray, mass: ndarray, rho: ndarray, h: ndarray,
-                             weight_function: CPUDispatcher, kernel_radius: float, pixels: int, x1: float, x2: float,
-                             y1: float, y2: float) -> ndarray:
+    def interpolate_2d_line(target: ndarray, x: ndarray, y: ndarray, mass: ndarray, rho: ndarray, h: ndarray,
+                            weight_function: CPUDispatcher, kernel_radius: float, pixels: int, x1: float, x2: float,
+                            y1: float, y2: float) -> ndarray:
         return GPUBackend._fast_2d_cross(target, x, y, mass, rho, h, weight_function, kernel_radius, pixels, x1, x2,
                                              y1, y2)
 

--- a/sarracen/interpolate/gpu_backend.py
+++ b/sarracen/interpolate/gpu_backend.py
@@ -19,7 +19,7 @@ class GPUBackend(BaseBackend):
         if exact:
             return GPUBackend._exact_2d_render(target, x, y, mass, rho, h, x_pixels, y_pixels, x_min, x_max, y_min,
                                                y_max)
-        return GPUBackend._fast_2d(target, 0, x, y, np.zeros(len(target)), mass, rho, h, weight_function, kernel_radius,
+        return GPUBackend._fast_2d(target, x, y, np.zeros(len(target)), 0, mass, rho, h, weight_function, kernel_radius,
                                    x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2)
 
     @staticmethod
@@ -32,10 +32,11 @@ class GPUBackend(BaseBackend):
                                                 y_max),
                     GPUBackend._exact_2d_render(target_y, x, y, mass, rho, h, x_pixels, y_pixels, x_min, x_max, y_min,
                                                 y_max))
-        return (GPUBackend._fast_2d(target_x, 0, x, y, np.zeros(len(target_x)), mass, rho, h, weight_function,
-                                    kernel_radius, x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2),
-                GPUBackend._fast_2d(target_y, 0, x, y, np.zeros(len(target_y)), mass, rho, h, weight_function,
-                                    kernel_radius, x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2))
+        return (
+        GPUBackend._fast_2d(target_x, x, y, np.zeros(len(target_x)), 0, mass, rho, h, weight_function, kernel_radius,
+                            x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2),
+        GPUBackend._fast_2d(target_y, x, y, np.zeros(len(target_y)), 0, mass, rho, h, weight_function, kernel_radius,
+                            x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2))
 
     @staticmethod
     def interpolate_2d_cross(target: ndarray, x: ndarray, y: ndarray, mass: ndarray, rho: ndarray, h: ndarray,
@@ -51,7 +52,7 @@ class GPUBackend(BaseBackend):
         if exact:
             return GPUBackend._exact_3d_project(target, x, y, mass, rho, h, x_pixels, y_pixels, x_min, x_max, y_min,
                                                 y_max)
-        return GPUBackend._fast_2d(target, 0, x, y, np.zeros(len(target)), mass, rho, h, weight_function, kernel_radius,
+        return GPUBackend._fast_2d(target, x, y, np.zeros(len(target)), 0, mass, rho, h, weight_function, kernel_radius,
                                    x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2)
 
     @staticmethod
@@ -64,34 +65,34 @@ class GPUBackend(BaseBackend):
                                                  y_max),
                     GPUBackend._exact_3d_project(target_y, x, y, mass, rho, h, x_pixels, y_pixels, x_min, x_max, y_min,
                                                  y_max))
-        return (GPUBackend._fast_2d(target_x, 0, x, y, np.zeros(len(target_x)), mass, rho, h, weight_function,
-                                    kernel_radius, x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2),
-                GPUBackend._fast_2d(target_y, 0, x, y, np.zeros(len(target_y)), mass, rho, h, weight_function,
-                                    kernel_radius, x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2))
+        return (
+        GPUBackend._fast_2d(target_x, x, y, np.zeros(len(target_x)), 0, mass, rho, h, weight_function, kernel_radius,
+                            x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2),
+        GPUBackend._fast_2d(target_y, x, y, np.zeros(len(target_y)), 0, mass, rho, h, weight_function, kernel_radius,
+                            x_pixels, y_pixels, x_min, x_max, y_min, y_max, 2))
 
     @staticmethod
-    def interpolate_3d_cross(target: ndarray, z_slice: float, x: ndarray, y: ndarray, z: ndarray, mass: ndarray,
+    def interpolate_3d_cross(target: ndarray, x: ndarray, y: ndarray, z: float, z_slice: ndarray, mass: ndarray,
                              rho: ndarray, h: ndarray, weight_function: CPUDispatcher, kernel_radius: float,
-                             x_pixels: int, y_pixels: int, x_min: float, x_max: float, y_min: float,
-                             y_max: float) -> ndarray:
-        return GPUBackend._fast_2d(target, z_slice, x, y, z, mass, rho, h, weight_function, kernel_radius, x_pixels,
+                             x_pixels: int, y_pixels: int, x_min: float, x_max: float, y_min: float, y_max: float) -> ndarray:
+        return GPUBackend._fast_2d(target, x, y, z, z_slice, mass, rho, h, weight_function, kernel_radius, x_pixels,
                                    y_pixels, x_min, x_max, y_min, y_max, 3)
 
     @staticmethod
-    def interpolate_3d_cross_vec(target_x: ndarray, target_y: ndarray, z_slice: float, x: ndarray, y: ndarray,
-                                 z: ndarray, mass: ndarray, rho: ndarray, h: ndarray, weight_function: CPUDispatcher,
-                                 kernel_radius: float, x_pixels: int, y_pixels: int, x_min: float, x_max: float,
-                                 y_min: float, y_max: float) -> Tuple[ndarray, ndarray]:
-        return (GPUBackend._fast_2d(target_x, z_slice, x, y, z, mass, rho, h, weight_function, kernel_radius, x_pixels,
+    def interpolate_3d_cross_vec(target_x: ndarray, target_y: ndarray, x: ndarray, y: ndarray, z: ndarray,
+                                 z_slice: float, mass: ndarray, rho: ndarray, h: ndarray,
+                                 weight_function: CPUDispatcher, kernel_radius: float, x_pixels: int, y_pixels: int,
+                                 x_min: float, x_max: float, y_min: float, y_max: float) -> Tuple[ndarray, ndarray]:
+        return (GPUBackend._fast_2d(target_x, x, y, z, z_slice, mass, rho, h, weight_function, kernel_radius, x_pixels,
                                     y_pixels, x_min, x_max, y_min, y_max, 3),
-                GPUBackend._fast_2d(target_y, z_slice, x, y, z, mass, rho, h, weight_function, kernel_radius, x_pixels,
+                GPUBackend._fast_2d(target_y, x, y, z, z_slice, mass, rho, h, weight_function, kernel_radius, x_pixels,
                                     y_pixels, x_min, x_max, y_min, y_max, 3))
 
     # For the GPU, the numba code is compiled using a factory function approach. This is required
     # since a CUDA numba kernel cannot easily take weight_function as an argument.
     @staticmethod
-    def _fast_2d(target, z_slice, x_data, y_data, z_data, mass_data, rho_data, h_data, weight_function,
-                     kernel_radius, x_pixels, y_pixels, x_min, x_max, y_min, y_max, n_dims):
+    def _fast_2d(target, x_data, y_data, z_data, z_slice, mass_data, rho_data, h_data, weight_function,
+                 kernel_radius, x_pixels, y_pixels, x_min, x_max, y_min, y_max, n_dims):
         # Underlying GPU numba-compiled code for interpolation to a 2D grid. Used in interpolation of 2D data,
         # and column integration / cross-sections of 3D data.
         @cuda.jit(fastmath=True)

--- a/sarracen/interpolate/interpolate.py
+++ b/sarracen/interpolate/interpolate.py
@@ -398,7 +398,7 @@ def interpolate_2d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, 
                                   xlim[1], ylim[0], ylim[1], exact)
 
 
-def interpolate_2d_cross(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None,
+def interpolate_2d_line(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None,
                          kernel: BaseKernel = None, pixels: int = None, xlim: tuple[float, float] = None,
                          ylim: tuple[float, float] = None, backend: str = None) -> np.ndarray:
     """ Interpolate particle data across two directional axes to a 1D cross-section line.
@@ -456,7 +456,7 @@ def interpolate_2d_cross(data: 'SarracenDataFrame', target: str, x: str = None, 
         raise ValueError('pixcount must be greater than zero!')
 
     return get_backend(backend)\
-        .interpolate_2d_cross(data[target].to_numpy(), data[x].to_numpy(), data[y].to_numpy(), data['m'].to_numpy(),
+        .interpolate_2d_line(data[target].to_numpy(), data[x].to_numpy(), data[y].to_numpy(), data['m'].to_numpy(),
                               data['rho'].to_numpy(), data['h'].to_numpy(), kernel.w, kernel.get_radius(), pixels,
                               xlim[0], xlim[1], ylim[0], ylim[1])
 

--- a/sarracen/interpolate/interpolate.py
+++ b/sarracen/interpolate/interpolate.py
@@ -398,7 +398,7 @@ def interpolate_2d_vec(data: 'SarracenDataFrame', target_x: str, target_y: str, 
 
 
 def interpolate_2d_cross(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None,
-                         kernel: BaseKernel = None, pixels: int = 512, x1: float = None, x2: float = None,
+                         kernel: BaseKernel = None, pixels: int = None, x1: float = None, x2: float = None,
                          y1: float = None, y2: float = None, backend: str = None) -> np.ndarray:
     """ Interpolate particle data across two directional axes to a 1D cross-section line.
 
@@ -449,6 +449,7 @@ def interpolate_2d_cross(data: 'SarracenDataFrame', target: str, x: str = None, 
 
     kernel = kernel if kernel is not None else data.kernel
     backend = backend if backend is not None else data.backend
+    pixels = pixels if pixels is not None else 512
 
     if pixels <= 0:
         raise ValueError('pixcount must be greater than zero!')

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -137,9 +137,8 @@ def render(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None,
         Column label of the target variable.
     x, y, z: str, optional
         Column labels of the x, y & z directional axes. Defaults to the columns detected in `data`.
-    xsec: float or bool, optional.
-        For a 3D dataset, the z to take a cross-section at. If none, column interpolation is performed. 'True' takes
-        the cross section at the middle z value of the data.
+    xsec: float, optional.
+        For a 3D dataset, the z value to take a cross-section at. If none, column interpolation is performed.
     kernel: BaseKernel, optional
         Kernel to use for smoothing the target data. Defaults to the kernel specified in `data`.
     x_pixels, y_pixels: int, optional
@@ -191,7 +190,7 @@ def render(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None,
         image = interpolate_2d(data, target, x, y, kernel, x_pixels, y_pixels, xlim, ylim, exact, backend)
     else:
         if xsec is not None:
-            image = interpolate_3d_cross(data, target, x, y, z, None if xsec is True else xsec, kernel, rotation,
+            image = interpolate_3d_cross(data, target, x, y, z, xsec, kernel, rotation,
                                          rot_origin, x_pixels, y_pixels, xlim, ylim, backend)
         else:
             image = interpolate_3d(data, target, x, y, kernel, integral_samples, rotation, rot_origin, x_pixels,
@@ -296,7 +295,7 @@ def lineplot(data: 'SarracenDataFrame', target: str, x: str = None, y: str = Non
 
 
 def streamlines(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[str, str, str]], x: str = None,
-                y: str = None, z: str = None, z_slice: int = None, kernel: BaseKernel = None,
+                y: str = None, z: str = None, xsec: int = None, kernel: BaseKernel = None,
                 integral_samples: int = 1000, rotation: np.ndarray = None, rot_origin: np.ndarray = None,
                 x_pixels: int = None, y_pixels: int = None, xlim: tuple[float, float] = None,
                 ylim: tuple[float, float] = None, ax: Axes = None, exact: bool = None, backend: str = None,
@@ -314,7 +313,7 @@ def streamlines(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[
         Particle data, in a SarracenDataFrame.
     target: str tuple of shape (2) or (3).
         Column label of the target vector. Shape must match the # of dimensions in `data`.
-    z_slice: float
+    xsec: float
         The z to take a cross-section at. If none, column interpolation is performed.
     x, y, z: str, optional
         Column label of the x, y & z directional axes. Defaults to the columns detected in `data`.
@@ -368,11 +367,11 @@ def streamlines(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[
     elif data.get_dim() == 3:
         if not len(target) == 3:
             raise ValueError('Target vector is not 3-dimensional.')
-        if z_slice is None:
+        if xsec is None:
             img = interpolate_3d_vec(data, target[0], target[1], target[2], x, y, kernel, integral_samples, rotation,
                                      rot_origin, x_pixels, y_pixels, xlim, ylim, exact, backend)
         else:
-            img = interpolate_3d_cross_vec(data, target[0], target[1], target[2], z_slice, x, y, z, kernel, rotation,
+            img = interpolate_3d_cross_vec(data, target[0], target[1], target[2], xsec, x, y, z, kernel, rotation,
                                            rot_origin, x_pixels, y_pixels, xlim, ylim, backend)
     else:
         raise ValueError('`data` is not a valid number of dimensions.')
@@ -403,7 +402,7 @@ def streamlines(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[
 
 
 def arrowplot(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[str, str, str]], x: str = None,
-              y: str = None, z: str = None, z_slice: int = None, kernel: BaseKernel = None,
+              y: str = None, z: str = None, xsec: float = None, kernel: BaseKernel = None,
               integral_samples: int = 1000, rotation: np.ndarray = None, rot_origin: np.ndarray = None,
               x_arrows: int = None, y_arrows: int = None, xlim: tuple[float, float] = None,
               ylim: tuple[float, float] = None, ax: Axes = None, qkey: bool = True, qkey_kws=None, exact: bool = None,
@@ -421,7 +420,7 @@ def arrowplot(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[st
         Particle data, in a SarracenDataFrame.
     target: str tuple of shape (2) or (3).
         Column label of the target vector. Shape must match the # of dimensions in `data`.
-    z_slice: float
+    xsec: float
         The z to take a cross-section at. If none, column interpolation is performed.
     x, y, z: str, optional
         Column label of the x, y & z directional axes. Defaults to the columns detected in `data`.
@@ -481,14 +480,14 @@ def arrowplot(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[st
     elif data.get_dim() == 3:
         if not len(target) == 3:
             raise ValueError('Target vector is not 3-dimensional.')
-        if z_slice is None:
+        if xsec is None:
             img = interpolate_3d_vec(data, target[0], target[1], target[2], x, y, kernel, integral_samples, rotation,
                                      rot_origin, x_arrows, y_arrows, xlim, ylim, exact, backend)
         else:
             if exact:
                 raise UserWarning("Exact interpolation is not supported for 3D cross-sections.")
 
-            img = interpolate_3d_cross_vec(data, target[0], target[1], target[2], z_slice, x, y, z, kernel, rotation,
+            img = interpolate_3d_cross_vec(data, target[0], target[1], target[2], xsec, x, y, z, kernel, rotation,
                                            rot_origin, x_arrows, y_arrows, xlim, ylim, backend)
     else:
         raise ValueError('`data` is not a valid number of dimensions.')

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -5,7 +5,7 @@ from matplotlib.colors import Colormap
 from pandas import DataFrame, Series
 import numpy as np
 
-from sarracen.render import streamlines, arrowplot, render
+from sarracen.render import streamlines, arrowplot, render, lineplot
 from sarracen.kernels import CubicSplineKernel, BaseKernel
 
 
@@ -159,12 +159,19 @@ class SarracenDataFrame(DataFrame):
         return render(self, target, x, y, z, xsec, kernel, x_pixels, y_pixels, xlim, ylim, cmap, cbar, cbar_kws,
                       cbar_ax, ax, exact, backend, integral_samples, rotation, rot_origin, log_scale, **kwargs)
 
+    @_copy_doc(lineplot)
+    def lineplot(self, target: str, x: str = None, y: str = None, z: str = None,
+                 kernel: BaseKernel = None, pixels: int = None, xlim: tuple[float, float] = None,
+                 ylim: tuple[float, float] = None, zlim: tuple[float, float] = None, ax: Axes = None, backend: str = None,
+                 log_scale: bool = False, **kwargs):
+        return lineplot(self, target, x, y, z, kernel, pixels, xlim, ylim, zlim, ax, backend, log_scale, **kwargs)
+
     @_copy_doc(streamlines)
     def streamlines(self, target: Union[Tuple[str, str], Tuple[str, str, str]], x: str = None, y: str = None,
                     z: str = None, z_slice: int = None, kernel: BaseKernel = None, integral_samples: int = 1000,
                     rotation: np.ndarray = None, rot_origin: np.ndarray = None, x_pixels: int = None,
                     y_pixels: int = None, xlim: tuple[float, float] = None, ylim: tuple[float, float] = None,
-                    ax: Axes = None, exact: bool = None, backend: str = None, log_scale: bool = None, **kwargs) -> Axes:
+                    ax: Axes = None, exact: bool = None, backend: str = None, **kwargs) -> Axes:
         return streamlines(self, target, x, y, z, z_slice, kernel, integral_samples, rotation, rot_origin, x_pixels,
                            y_pixels, xlim, ylim, ax, exact, backend, **kwargs)
 
@@ -173,7 +180,7 @@ class SarracenDataFrame(DataFrame):
                   z: str = None, z_slice: int = None, kernel: BaseKernel = None, integral_samples: int = 1000,
                   rotation: np.ndarray = None, rot_origin: np.ndarray = None, x_arrows: int = None,
                   y_arrows: int = None, xlim: tuple[float, float] = None, ylim: tuple[float, float] = None,
-                  ax: Axes = None, exact: bool = None, backend: str = None, log_scale: bool = None, **kwargs) -> Axes:
+                  ax: Axes = None, exact: bool = None, backend: str = None, **kwargs) -> Axes:
         return arrowplot(self, target, z_slice, x, y, z, kernel, integral_samples, rotation, rot_origin, x_arrows,
                          y_arrows, xlim, ylim, ax, exact, backend, **kwargs)
 

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -166,7 +166,7 @@ class SarracenDataFrame(DataFrame):
                     y_pixels: int = None, xlim: tuple[float, float] = None, ylim: tuple[float, float] = None,
                     ax: Axes = None, exact: bool = None, backend: str = None, log_scale: bool = None, **kwargs) -> Axes:
         return streamlines(self, target, x, y, z, z_slice, kernel, integral_samples, rotation, rot_origin, x_pixels,
-                           y_pixels, xlim, ylim, ax, exact, backend, log_scale, **kwargs)
+                           y_pixels, xlim, ylim, ax, exact, backend, **kwargs)
 
     @_copy_doc(arrowplot)
     def arrowplot(self, target: Union[Tuple[str, str], Tuple[str, str, str]], x: str = None, y: str = None,
@@ -175,7 +175,7 @@ class SarracenDataFrame(DataFrame):
                   y_arrows: int = None, xlim: tuple[float, float] = None, ylim: tuple[float, float] = None,
                   ax: Axes = None, exact: bool = None, backend: str = None, log_scale: bool = None, **kwargs) -> Axes:
         return arrowplot(self, target, z_slice, x, y, z, kernel, integral_samples, rotation, rot_origin, x_arrows,
-                         y_arrows, xlim, ylim, ax, exact, backend, log_scale, **kwargs)
+                         y_arrows, xlim, ylim, ax, exact, backend, **kwargs)
 
     @property
     def params(self):

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -150,32 +150,32 @@ class SarracenDataFrame(DataFrame):
         self._rhocol = 'rho'
 
     @_copy_doc(render)
-    def render(self, target: str, xsec: float = None, x: str = None, y: str = None, z: str = None,
-               kernel: BaseKernel = None, x_pixels: int = None, y_pixels: int = None, x1: float = None,
-               x2: float = None, y1: float = None, y2: float = None, cmap: Union[str, Colormap] = 'RdBu',
-               cbar: bool = True, cbar_kws: dict = {}, cbar_ax: Axes = None, ax: Axes = None, exact: bool = None,
-               backend: str = None, integral_samples: int = 1000, rotation: np.ndarray = None,
-               rot_origin: np.ndarray = None, **kwargs) -> Axes:
-        return render(self, target, xsec, x, y, z, kernel, x_pixels, y_pixels, x1, x2, y1, y2, cmap, cbar, cbar_kws,
+    def render(self, target: str, x: str = None, y: str = None, z: str = None, xsec: float = None,
+               kernel: BaseKernel = None, x_pixels: int = None, y_pixels: int = None, xlim: tuple[float, float] = None,
+               ylim: tuple[float, float] = None, cmap: Union[str, Colormap] = 'RdBu', cbar: bool = True,
+               cbar_kws: dict = {}, cbar_ax: Axes = None, ax: Axes = None, exact: bool = None, backend: str = None,
+               integral_samples: int = 1000, rotation: np.ndarray = None, rot_origin: np.ndarray = None,
+               **kwargs) -> Axes:
+        return render(self, target, x, y, z, xsec, kernel, x_pixels, y_pixels, xlim, ylim, cmap, cbar, cbar_kws,
                       cbar_ax, ax, exact, backend, integral_samples, rotation, rot_origin, **kwargs)
 
     @_copy_doc(streamlines)
-    def streamlines(self, target: Union[Tuple[str, str], Tuple[str, str, str]], z_slice: int = None, x: str = None,
-                    y: str = None, z: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
+    def streamlines(self, target: Union[Tuple[str, str], Tuple[str, str, str]], x: str = None, y: str = None,
+                    z: str = None, z_slice: int = None, kernel: BaseKernel = None, integral_samples: int = 1000,
                     rotation: np.ndarray = None, rot_origin: np.ndarray = None, x_pixels: int = None,
-                    y_pixels: int = None, x1: float = None, x2: float = None, y1: float = None,
-                    y2: float = None, ax: Axes = None, exact: bool = None, backend: str = None, **kwargs) -> Axes:
-        return streamlines(self, target, z_slice, x, y, z, kernel, integral_samples, rotation, rot_origin, x_pixels,
-                           y_pixels, x1, x2, y1, y2, ax, exact, backend, **kwargs)
+                    y_pixels: int = None, xlim: tuple[float, float] = None, ylim: tuple[float, float] = None,
+                    ax: Axes = None, exact: bool = None, backend: str = None, **kwargs) -> Axes:
+        return streamlines(self, target, x, y, z, z_slice, kernel, integral_samples, rotation, rot_origin, x_pixels,
+                           y_pixels, xlim, ylim, ax, exact, backend, **kwargs)
 
     @_copy_doc(arrowplot)
-    def arrowplot(self, target: Union[Tuple[str, str], Tuple[str, str, str]], z_slice: int = None, x: str = None,
-                  y: str = None, z: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
+    def arrowplot(self, target: Union[Tuple[str, str], Tuple[str, str, str]], x: str = None, y: str = None,
+                  z: str = None, z_slice: int = None, kernel: BaseKernel = None, integral_samples: int = 1000,
                   rotation: np.ndarray = None, rot_origin: np.ndarray = None, x_arrows: int = None,
-                  y_arrows: int = None, x1: float = None, x2: float = None, y1: float = None,
-                  y2: float = None, ax: Axes = None, exact: bool = None, backend: str = None, **kwargs) -> Axes:
+                  y_arrows: int = None, xlim: tuple[float, float] = None, ylim: tuple[float, float] = None,
+                  ax: Axes = None, exact: bool = None, backend: str = None, **kwargs) -> Axes:
         return arrowplot(self, target, z_slice, x, y, z, kernel, integral_samples, rotation, rot_origin, x_arrows,
-                         y_arrows, x1, x2, y1, y2, ax, exact, backend, **kwargs)
+                         y_arrows, xlim, ylim, ax, exact, backend, **kwargs)
 
     @property
     def params(self):

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -5,7 +5,7 @@ from matplotlib.colors import Colormap
 from pandas import DataFrame, Series
 import numpy as np
 
-from sarracen.render import render_2d, render_2d_cross, render_3d, render_3d_cross, streamlines, arrowplot
+from sarracen.render import streamlines, arrowplot, render
 from sarracen.kernels import CubicSplineKernel, BaseKernel
 
 
@@ -149,61 +149,33 @@ class SarracenDataFrame(DataFrame):
         self['rho'] = (self.params['hfact'] / self['h']) ** (self.get_dim()) * self['m']
         self._rhocol = 'rho'
 
-    @_copy_doc(render_2d)
-    def render_2d(self, target: str, x: str = None, y: str = None, kernel: BaseKernel = None, x_pixels: int = None,
-                  y_pixels: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
-                  y_max: float = None, cmap: Union[str, Colormap] = 'RdBu', cbar: bool = True, cbar_kws: dict = {},
-                  cbar_ax: Axes = None, ax: Axes = None, exact: bool = None, backend: str = None, **kwargs) -> Axes:
-
-        return render_2d(self, target, x, y, kernel, x_pixels, y_pixels, x_min, x_max, y_min, y_max, cmap, cbar,
-                         cbar_kws, cbar_ax, ax, exact, backend, **kwargs)
-
-    @_copy_doc(render_2d_cross)
-    def render_2d_cross(self, target: str, x: str = None, y: str = None, kernel: BaseKernel = None, pixels: int = 512,
-                        x1: float = None, y1: float = None, x2: float = None, y2: float = None, ax: Axes = None,
-                        backend: str = None, **kwargs) -> Axes:
-
-        return render_2d_cross(self, target, x, y, kernel, pixels, x1, x2, y1, y2, ax, backend, **kwargs)
-
-    @_copy_doc(render_3d)
-    def render_3d(self, target: str, x: str = None, y: str = None, kernel: BaseKernel = None,
-                  int_samples: int = 1000, rotation: np.ndarray = None, rot_origin: np.ndarray = None,
-                  x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None,
-                  y_min: float = None, y_max: float = None, cmap: Union[str, Colormap] = 'RdBu', cbar: bool = True,
-                  cbar_kws: dict = {}, cbar_ax: Axes = None, ax: Axes = None, exact: bool = None, backend: str = None,
-                  **kwargs) -> Axes:
-
-        return render_3d(self, target, x, y, kernel, int_samples, rotation, rot_origin, x_pixels, y_pixels, x_min,
-                         x_max, y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, exact, backend, **kwargs)
-
-    @_copy_doc(render_3d_cross)
-    def render_3d_cross(self, target: str, z_slice: float = None, x: str = None, y: str = None, z: str = None,
-                        kernel: BaseKernel = None, rotation: np.ndarray = None, rot_origin: np.ndarray = None,
-                        x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None,
-                        y_min: float = None, y_max: float = None, cmap: Union[str, Colormap] = 'RdBu',
-                        cbar: bool = True, cbar_kws: dict = {}, cbar_ax: Axes = None, ax: Axes = None,
-                        backend: str = None, **kwargs) -> Axes:
-
-        return render_3d_cross(self, target, z_slice, x, y, z, kernel, rotation, rot_origin, x_pixels, y_pixels, x_min,
-                               x_max, y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, backend, **kwargs)
+    @_copy_doc(render)
+    def render(self, target: str, xsec: float = None, x: str = None, y: str = None, z: str = None,
+               kernel: BaseKernel = None, x_pixels: int = None, y_pixels: int = None, x1: float = None,
+               x2: float = None, y1: float = None, y2: float = None, cmap: Union[str, Colormap] = 'RdBu',
+               cbar: bool = True, cbar_kws: dict = {}, cbar_ax: Axes = None, ax: Axes = None, exact: bool = None,
+               backend: str = None, integral_samples: int = 1000, rotation: np.ndarray = None,
+               rot_origin: np.ndarray = None, **kwargs) -> Axes:
+        return render(self, target, xsec, x, y, z, kernel, x_pixels, y_pixels, x1, x2, y1, y2, cmap, cbar, cbar_kws,
+                      cbar_ax, ax, exact, backend, integral_samples, rotation, rot_origin, **kwargs)
 
     @_copy_doc(streamlines)
     def streamlines(self, target: Union[Tuple[str, str], Tuple[str, str, str]], z_slice: int = None, x: str = None,
                     y: str = None, z: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
                     rotation: np.ndarray = None, rot_origin: np.ndarray = None, x_pixels: int = None,
-                    y_pixels: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
-                    y_max: float = None, ax: Axes = None, exact: bool = None, backend: str='cpu', **kwargs) -> Axes:
+                    y_pixels: int = None, x1: float = None, x2: float = None, y1: float = None,
+                    y2: float = None, ax: Axes = None, exact: bool = None, backend: str = None, **kwargs) -> Axes:
         return streamlines(self, target, z_slice, x, y, z, kernel, integral_samples, rotation, rot_origin, x_pixels,
-                           y_pixels, x_min, x_max, y_min, y_max, ax, exact, backend, **kwargs)
+                           y_pixels, x1, x2, y1, y2, ax, exact, backend, **kwargs)
 
     @_copy_doc(arrowplot)
     def arrowplot(self, target: Union[Tuple[str, str], Tuple[str, str, str]], z_slice: int = None, x: str = None,
                   y: str = None, z: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
                   rotation: np.ndarray = None, rot_origin: np.ndarray = None, x_arrows: int = None,
-                  y_arrows: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
-                  y_max: float = None, ax: Axes = None, exact: bool = None, backend: str='cpu', **kwargs) -> Axes:
+                  y_arrows: int = None, x1: float = None, x2: float = None, y1: float = None,
+                  y2: float = None, ax: Axes = None, exact: bool = None, backend: str = None, **kwargs) -> Axes:
         return arrowplot(self, target, z_slice, x, y, z, kernel, integral_samples, rotation, rot_origin, x_arrows,
-                         y_arrows, x_min, x_max, y_min, y_max, ax, exact, backend, **kwargs)
+                         y_arrows, x1, x2, y1, y2, ax, exact, backend, **kwargs)
 
     @property
     def params(self):

--- a/sarracen/tests/test_interpolate.py
+++ b/sarracen/tests/test_interpolate.py
@@ -36,11 +36,11 @@ def test_single_particle(backend):
     # A mapping of pixel indices to x / y values in particle space.
     real = -kernel.get_radius() + (np.arange(0, 25) + 0.5) * (2 * kernel.get_radius() / 25)
 
-
-    image = interpolate_2d(sdf, 'A', x_pixels=25,  y_pixels=25, x_min=-kernel.get_radius(), x_max=kernel.get_radius(),
-                           y_min=-kernel.get_radius(), y_max=kernel.get_radius())
-    image_vec = interpolate_2d_vec(sdf, 'A', 'B', x_pixels=25, y_pixels=25, x_min=-kernel.get_radius(),
-                               x_max=kernel.get_radius(), y_min=-kernel.get_radius(), y_max=kernel.get_radius())
+    image = interpolate_2d(sdf, 'A', x_pixels=25,  y_pixels=25, xlim=(-kernel.get_radius(), kernel.get_radius()),
+                           ylim=(-kernel.get_radius(), kernel.get_radius()))
+    image_vec = interpolate_2d_vec(sdf, 'A', 'B', x_pixels=25, y_pixels=25,
+                                   xlim=(-kernel.get_radius(), kernel.get_radius()),
+                                   ylim=(-kernel.get_radius(), kernel.get_radius()))
     for y in range(25):
         for x in range(25):
             assert image[y][x] ==\
@@ -50,8 +50,8 @@ def test_single_particle(backend):
             assert image_vec[1][y][x] == \
                    approx(w[0] * sdf['B'][0] * kernel.w(np.sqrt(real[x] ** 2 + real[y] ** 2) / sdf['h'][0], 2))
 
-    image = interpolate_2d_cross(sdf, 'A', pixels=25, x1=-kernel.get_radius(), x2=kernel.get_radius(),
-                                 y1=-kernel.get_radius(), y2=kernel.get_radius())
+    image = interpolate_2d_cross(sdf, 'A', pixels=25, xlim=(-kernel.get_radius(), kernel.get_radius()),
+                                 ylim=(-kernel.get_radius(), kernel.get_radius()))
     for x in range(25):
         assert image[x] == approx(w[0] * sdf['A'][0] * kernel.w(np.sqrt(2) * np.abs(real[x]) / sdf['h'][0], 2))
 
@@ -62,10 +62,11 @@ def test_single_particle(backend):
 
     column_func = kernel.get_column_kernel_func(1000)
 
-    image = interpolate_3d(sdf, 'A', x_pixels=25, y_pixels=25, x_min=-kernel.get_radius(), x_max=kernel.get_radius(),
-                           y_min=-kernel.get_radius(), y_max=kernel.get_radius())
-    image_vec = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=25, y_pixels=25, x_min=-kernel.get_radius(),
-                               x_max=kernel.get_radius(), y_min=-kernel.get_radius(), y_max=kernel.get_radius())
+    image = interpolate_3d(sdf, 'A', x_pixels=25, y_pixels=25, xlim=(-kernel.get_radius(), kernel.get_radius()),
+                           ylim=(-kernel.get_radius(), kernel.get_radius()))
+    image_vec = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=25, y_pixels=25,
+                                   xlim=(-kernel.get_radius(), kernel.get_radius()),
+                                   ylim=(-kernel.get_radius(), kernel.get_radius()))
     for y in range(25):
         for x in range(25):
             assert image[y][x] ==\
@@ -78,10 +79,12 @@ def test_single_particle(backend):
     # Weight for 3D cross-sections.
     w = sdf['m'] / (sdf['rho'] * sdf['h'] ** 3)
 
-    image = interpolate_3d_cross(sdf, 'A', 0, x_pixels=25, y_pixels=25, x_min=-kernel.get_radius(),
-                                 x_max=kernel.get_radius(), y_min=-kernel.get_radius(), y_max=kernel.get_radius())
-    image_vec = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x_pixels=25, y_pixels=25, x_min=-kernel.get_radius(),
-                                     x_max=kernel.get_radius(), y_min=-kernel.get_radius(), y_max=kernel.get_radius())
+    image = interpolate_3d_cross(sdf, 'A', z_slice=0, x_pixels=25, y_pixels=25,
+                                 xlim=(-kernel.get_radius(), kernel.get_radius()),
+                                 ylim=(-kernel.get_radius(), kernel.get_radius()))
+    image_vec = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x_pixels=25, y_pixels=25,
+                                         xlim=(-kernel.get_radius(), kernel.get_radius()),
+                                         ylim=(-kernel.get_radius(), kernel.get_radius()))
     for y in range(25):
         for x in range(25):
             assert image[y][x] == approx(w[0] * sdf['A'][0] *
@@ -118,10 +121,11 @@ def test_single_repeated_particle(backend):
     # A mapping of pixel indices to x / y values in particle space.
     real = -kernel.get_radius() + (np.arange(0, 25) + 0.5) * (2 * kernel.get_radius() / 25)
 
-    image = interpolate_2d(sdf, 'A', x_pixels=25, y_pixels=25, x_min=-kernel.get_radius(), x_max=kernel.get_radius(),
-                           y_min=-kernel.get_radius(), y_max=kernel.get_radius())
-    image_vec = interpolate_2d_vec(sdf, 'A', 'B', x_pixels=25, y_pixels=25, x_min=-kernel.get_radius(),
-                               x_max=kernel.get_radius(), y_min=-kernel.get_radius(), y_max=kernel.get_radius())
+    image = interpolate_2d(sdf, 'A', x_pixels=25, y_pixels=25, xlim=(-kernel.get_radius(), kernel.get_radius()),
+                           ylim=(-kernel.get_radius(), kernel.get_radius()))
+    image_vec = interpolate_2d_vec(sdf, 'A', 'B', x_pixels=25, y_pixels=25,
+                                   xlim=(-kernel.get_radius(), kernel.get_radius()),
+                                   ylim=(-kernel.get_radius(), kernel.get_radius()))
     for y in range(25):
         for x in range(25):
             assert image[y][x] == \
@@ -131,8 +135,8 @@ def test_single_repeated_particle(backend):
             assert image_vec[1][y][x] == \
                    approx(w[0] * sdf['B'][0] * kernel.w(np.sqrt(real[x] ** 2 + real[y] ** 2) / sdf['h'][0], 2))
 
-    image = interpolate_2d_cross(sdf, 'A', pixels=25, x1=-kernel.get_radius(), x2=kernel.get_radius(),
-                                 y1=-kernel.get_radius(), y2=kernel.get_radius())
+    image = interpolate_2d_cross(sdf, 'A', pixels=25, xlim=(-kernel.get_radius(), kernel.get_radius()),
+                                 ylim=(-kernel.get_radius(), kernel.get_radius()))
     for x in range(25):
         assert image[x] == approx(w[0] * sdf['A'][0] * kernel.w(np.sqrt(2) * np.abs(real[x]) / sdf['h'][0], 2))
 
@@ -143,10 +147,11 @@ def test_single_repeated_particle(backend):
 
     column_func = kernel.get_column_kernel_func(1000)
 
-    image = interpolate_3d(sdf, 'A', x_pixels=25, y_pixels=25, x_min=-kernel.get_radius(), x_max=kernel.get_radius(),
-                           y_min=-kernel.get_radius(), y_max=kernel.get_radius())
-    image_vec = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=25, y_pixels=25, x_min=-kernel.get_radius(),
-                               x_max=kernel.get_radius(), y_min=-kernel.get_radius(), y_max=kernel.get_radius())
+    image = interpolate_3d(sdf, 'A', x_pixels=25, y_pixels=25, xlim=(-kernel.get_radius(), kernel.get_radius()),
+                           ylim=(-kernel.get_radius(), kernel.get_radius()))
+    image_vec = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=25, y_pixels=25,
+                                   xlim=(-kernel.get_radius(), kernel.get_radius()),
+                                   ylim=(-kernel.get_radius(), kernel.get_radius()))
     for y in range(25):
         for x in range(25):
             assert image[y][x] == \
@@ -159,10 +164,12 @@ def test_single_repeated_particle(backend):
     # Weight for 3D cross-sections
     w = repetitions * sdf['m'] / (sdf['rho'] * sdf['h'] ** 3)
 
-    image = interpolate_3d_cross(sdf, 'A', 0, x_pixels=25, y_pixels=25, x_min=-kernel.get_radius(),
-                                 x_max=kernel.get_radius(), y_min=-kernel.get_radius(), y_max=kernel.get_radius())
-    image_vec = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x_pixels=25, y_pixels=25, x_min=-kernel.get_radius(),
-                                     x_max=kernel.get_radius(), y_min=-kernel.get_radius(), y_max=kernel.get_radius())
+    image = interpolate_3d_cross(sdf, 'A', z_slice=0, x_pixels=25, y_pixels=25,
+                                 xlim=(-kernel.get_radius(), kernel.get_radius()),
+                                 ylim=(-kernel.get_radius(), kernel.get_radius()))
+    image_vec = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x_pixels=25, y_pixels=25,
+                                         xlim=(-kernel.get_radius(), kernel.get_radius()),
+                                         ylim=(-kernel.get_radius(), kernel.get_radius()))
     for y in range(25):
         for x in range(25):
             assert image[y][x] == approx(w[0] * sdf['A'][0] *
@@ -221,15 +228,15 @@ def test_3d_xsec_equivalency(backend):
 
     samples = 250
 
-    column_image = interpolate_3d(sdf, 'A', x_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1)
-    column_image_vec = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1)
+    column_image = interpolate_3d(sdf, 'A', x_pixels=50, xlim=(-1, 1), ylim=(-1, 1))
+    column_image_vec = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=50, xlim=(-1, 1), ylim=(-1, 1))
 
     xsec_image = np.zeros((50, 50))
     xsec_image_vec = [np.zeros((50, 50)), np.zeros((50, 50))]
     for z in np.linspace(0, kernel.get_radius() * sdf['h'][0], samples):
-        xsec_image += interpolate_3d_cross(sdf, 'A', z, x_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1)
+        xsec_image += interpolate_3d_cross(sdf, 'A', z_slice=z, x_pixels=50, xlim=(-1, 1), ylim=(-1, 1))
 
-        vec_sample = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', z, x_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1)
+        vec_sample = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', z, x_pixels=50, xlim=(-1, 1), ylim=(-1, 1))
         xsec_image_vec[0] += vec_sample[0]
         xsec_image_vec[1] += vec_sample[1]
 
@@ -259,19 +266,19 @@ def test_2d_xsec_equivalency(backend):
     sdf.kernel = kernel
     sdf.backend = backend
 
-    true_image = interpolate_2d(sdf, 'A', x_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1)
+    true_image = interpolate_2d(sdf, 'A', x_pixels=50, xlim=(-1, 1), ylim=(-1, 1))
 
     # A mapping of pixel indices to x & y values in particle space.
     real = -1 + (np.arange(0, 50) + 0.5) * (2 / 50)
 
     reconstructed_image = np.zeros((50, 50))
     for y in range(50):
-        reconstructed_image[y, :] = interpolate_2d_cross(sdf, 'A', pixels=50, x1=-1, x2=1, y1=real[y], y2=real[y])
+        reconstructed_image[y, :] = interpolate_2d_cross(sdf, 'A', pixels=50, xlim=(-1, 1), ylim=(real[y], real[y]))
     assert_allclose(reconstructed_image, true_image)
 
     reconstructed_image = np.zeros((50, 50))
     for x in range(50):
-        reconstructed_image[:, x] = interpolate_2d_cross(sdf, 'A', pixels=50, x1=real[x], x2=real[x], y1=-1, y2=1)
+        reconstructed_image[:, x] = interpolate_2d_cross(sdf, 'A', pixels=50, xlim=(real[x], real[x]), ylim=(-1, 1))
     assert_allclose(reconstructed_image, true_image)
 
 
@@ -382,12 +389,12 @@ def test_image_transpose(backend):
     assert_allclose(image1, image2.T)
 
     image1 = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=50, y_pixels=50)
-    image2 = interpolate_3d_vec(sdf, 'A', 'B', 'C', x='y', y='x', x_pixels=50, y_pixels=50, y_max=1)
+    image2 = interpolate_3d_vec(sdf, 'A', 'B', 'C', x='y', y='x', x_pixels=50, y_pixels=50)
     assert_allclose(image1[0], image2[0].T)
     assert_allclose(image1[1], image2[1].T)
 
-    image1 = interpolate_3d_cross(sdf, 'A', x_pixels=50,  y_pixels=50)
-    image2 = interpolate_3d_cross(sdf, 'A', x='y', y='x', x_pixels=50,  y_pixels=50)
+    image1 = interpolate_3d_cross(sdf, 'A', x_pixels=50, y_pixels=50)
+    image2 = interpolate_3d_cross(sdf, 'A', x='y', y='x', x_pixels=50, y_pixels=50)
     assert_allclose(image1, image2.T)
 
     image1 = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', x_pixels=50, y_pixels=50)
@@ -416,50 +423,47 @@ def test_default_kernel(backend):
     # First, test that the dataframe kernel is used in cases with no kernel supplied.
 
     # Each interpolation is performed over one pixel, offering an easy way to check the kernel used by the function.
-    image = interpolate_2d(sdf_2, 'A', x_pixels=1, y_pixels=1, x_min=-1, x_max=1, y_min=-1, y_max=1)
+    image = interpolate_2d(sdf_2, 'A', x_pixels=1, y_pixels=1, xlim=(-1, 1), ylim=(-1, 1))
     assert image == kernel.w(0, 2)
-    image = interpolate_2d_vec(sdf_2, 'A', 'B', x_pixels=1, y_pixels=1, x_min=-1, x_max=1, y_min=-1, y_max=1)
+    image = interpolate_2d_vec(sdf_2, 'A', 'B', x_pixels=1, y_pixels=1, xlim=(-1, 1), ylim=(-1, 1))
     assert image[0] == kernel.w(0, 2)
     assert image[1] == kernel.w(0, 2)
 
-    image = interpolate_2d_cross(sdf_2, 'A', pixels=1, x1=-1, x2=1, y1=-1, y2=1)
+    image = interpolate_2d_cross(sdf_2, 'A', pixels=1, xlim=(-1, 1), ylim=(-1, 1))
     assert image == kernel.w(0, 2)
 
-    image = interpolate_3d(sdf_3, 'A', x_pixels=1, y_pixels=1, x_min=-1, x_max=1, y_min=-1, y_max=1)
+    image = interpolate_3d(sdf_3, 'A', x_pixels=1, y_pixels=1, xlim=(-1, 1), ylim=(-1, 1))
     assert image == kernel.get_column_kernel()[0]
-    image = interpolate_3d_vec(sdf_3, 'A', 'B', 'C', x_pixels=1, y_pixels=1, x_min=-1, x_max=1, y_min=-1, y_max=1)
+    image = interpolate_3d_vec(sdf_3, 'A', 'B', 'C', x_pixels=1, y_pixels=1, xlim=(-1, 1), ylim=(-1, 1))
     assert image[0] == kernel.get_column_kernel()[0]
     assert image[1] == kernel.get_column_kernel()[0]
 
-    image = interpolate_3d_cross(sdf_3, 'A', x_pixels=1, y_pixels=1, x_min=-1, x_max=1, y_min=-1, y_max=1)
+    image = interpolate_3d_cross(sdf_3, 'A', x_pixels=1, y_pixels=1, xlim=(-1, 1), ylim=(-1, 1))
     assert image == kernel.w(0, 3)
-    image = interpolate_3d_cross_vec(sdf_3, 'A', 'B', 'C', x_pixels=1, y_pixels=1, x_min=-1, x_max=1, y_min=-1, y_max=1)
+    image = interpolate_3d_cross_vec(sdf_3, 'A', 'B', 'C', x_pixels=1, y_pixels=1, xlim=(-1, 1), ylim=(-1, 1))
     assert image[0] == kernel.w(0, 3)
     assert image[1] == kernel.w(0, 3)
 
     # Next, test that the kernel supplied to the function is actually used.
     kernel = QuinticSplineKernel()
-    image = interpolate_2d(sdf_2, 'A', x_pixels=1, y_pixels=1, x_min=-1, x_max=1, y_min=-1, y_max=1, kernel=kernel)
+    image = interpolate_2d(sdf_2, 'A', x_pixels=1, y_pixels=1, xlim=(-1, 1), ylim=(-1, 1), kernel=kernel)
     assert image == kernel.w(0, 2)
-    image = interpolate_2d_vec(sdf_2, 'A', 'B', x_pixels=1, y_pixels=1, x_min=-1, x_max=1, y_min=-1, y_max=1,
-                               kernel=kernel)
+    image = interpolate_2d_vec(sdf_2, 'A', 'B', x_pixels=1, y_pixels=1, xlim=(-1, 1), ylim=(-1, 1), kernel=kernel)
     assert image[0] == kernel.w(0, 2)
     assert image[1] == kernel.w(0, 2)
 
-    image = interpolate_2d_cross(sdf_2, 'A', pixels=1, x1=-1, x2=1, y1=-1, y2=1, kernel=kernel)
+    image = interpolate_2d_cross(sdf_2, 'A', pixels=1, xlim=(-1, 1), ylim=(-1, 1), kernel=kernel)
     assert image == kernel.w(0, 2)
 
-    image = interpolate_3d(sdf_3, 'A', x_pixels=1, y_pixels=1, x_min=-1, x_max=1, y_min=-1, y_max=1, kernel=kernel)
+    image = interpolate_3d(sdf_3, 'A', x_pixels=1, y_pixels=1, xlim=(-1, 1), ylim=(-1, 1), kernel=kernel)
     assert image == kernel.get_column_kernel()[0]
-    image = interpolate_3d_vec(sdf_3, 'A', 'B', 'C', x_pixels=1, y_pixels=1, x_min=-1, x_max=1, y_min=-1, y_max=1,
-                               kernel=kernel)
+    image = interpolate_3d_vec(sdf_3, 'A', 'B', 'C', x_pixels=1, y_pixels=1, xlim=(-1, 1), ylim=(-1, 1), kernel=kernel)
     assert image[0] == kernel.get_column_kernel()[0]
     assert image[1] == kernel.get_column_kernel()[0]
 
-    image = interpolate_3d_cross(sdf_3, 'A', x_pixels=1, y_pixels=1, x_min=-1, x_max=1, y_min=-1, y_max=1,
-                                 kernel=kernel)
+    image = interpolate_3d_cross(sdf_3, 'A', kernel=kernel, x_pixels=1, y_pixels=1, xlim=(-1, 1), ylim=(-1, 1))
     assert image == kernel.w(0, 3)
-    image = interpolate_3d_cross_vec(sdf_3, 'A', 'B', 'C', x_pixels=1, y_pixels=1, x_min=-1, x_max=1, y_min=-1, y_max=1,
+    image = interpolate_3d_cross_vec(sdf_3, 'A', 'B', 'C', x_pixels=1, y_pixels=1, xlim=(-1, 1), ylim=(-1, 1),
                                      kernel=kernel)
     assert image[0] == kernel.w(0, 3)
     assert image[1] == kernel.w(0, 3)
@@ -478,7 +482,7 @@ def test_column_samples(backend):
 
     # 2 samples is used here, since a column kernel with 2 samples will be drastically different than the
     # default kernel of 1000 samples.
-    image = interpolate_3d(sdf_3, 'A', x_pixels=1, y_pixels=1, x_min=-1, x_max=1, y_min=-1, y_max=1, integral_samples=2)
+    image = interpolate_3d(sdf_3, 'A', x_pixels=1, y_pixels=1, xlim=(-1, 1), ylim=(-1, 1), integral_samples=2)
     assert image == kernel.get_column_kernel(2)[0]
 
 
@@ -589,10 +593,11 @@ def test_irregular_bounds(backend):
     real_x = -kernel.get_radius() + (np.arange(0, 50) + 0.5) * (2 * kernel.get_radius() / 50)
     real_y = -kernel.get_radius() + (np.arange(0, 25) + 0.5) * (2 * kernel.get_radius() / 25)
 
-    image = interpolate_2d(sdf, 'A', x_pixels=50, y_pixels=25, x_min=-kernel.get_radius(), x_max=kernel.get_radius(),
-                           y_min=-kernel.get_radius(), y_max=kernel.get_radius())
-    image_vec = interpolate_2d_vec(sdf, 'A', 'B', x_pixels=50, y_pixels=25, x_min=-kernel.get_radius(),
-                                   x_max=kernel.get_radius(), y_min=-kernel.get_radius(), y_max=kernel.get_radius())
+    image = interpolate_2d(sdf, 'A', x_pixels=50, y_pixels=25, xlim=(-kernel.get_radius(), kernel.get_radius()),
+                           ylim=(-kernel.get_radius(), kernel.get_radius()))
+    image_vec = interpolate_2d_vec(sdf, 'A', 'B', x_pixels=50, y_pixels=25,
+                                   xlim=(-kernel.get_radius(), kernel.get_radius()),
+                                   ylim=(-kernel.get_radius(), kernel.get_radius()))
     for y in range(25):
         for x in range(50):
             assert image[y][x] == approx(
@@ -609,10 +614,11 @@ def test_irregular_bounds(backend):
 
     column_func = kernel.get_column_kernel_func(1000)
 
-    image = interpolate_3d(sdf, 'A', x_pixels=50, y_pixels=25, x_min=-kernel.get_radius(), x_max=kernel.get_radius(),
-                           y_min=-kernel.get_radius(), y_max=kernel.get_radius())
-    image_vec = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=50, y_pixels=25, x_min=-kernel.get_radius(),
-                                   x_max=kernel.get_radius(), y_min=-kernel.get_radius(), y_max=kernel.get_radius())
+    image = interpolate_3d(sdf, 'A', x_pixels=50, y_pixels=25, xlim=(-kernel.get_radius(), kernel.get_radius()),
+                           ylim=(-kernel.get_radius(), kernel.get_radius()))
+    image_vec = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=50, y_pixels=25,
+                                   xlim=(-kernel.get_radius(), kernel.get_radius()),
+                                   ylim=(-kernel.get_radius(), kernel.get_radius()))
     for y in range(25):
         for x in range(50):
             assert image[y][x] == approx(
@@ -625,10 +631,12 @@ def test_irregular_bounds(backend):
     # Weight for 3D cross-section interpolation.
     w = sdf['m'] / (sdf['rho'] * sdf['h'] ** 3)
 
-    image = interpolate_3d_cross(sdf, 'A', 0, x_pixels=50, y_pixels=25, x_min=-kernel.get_radius(),
-                                 x_max=kernel.get_radius(), y_min=-kernel.get_radius(), y_max=kernel.get_radius())
-    image_vec = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x_pixels=50, y_pixels=25, x_min=-kernel.get_radius(),
-                                     x_max=kernel.get_radius(), y_min=-kernel.get_radius(), y_max=kernel.get_radius())
+    image = interpolate_3d_cross(sdf, 'A', z_slice=0, x_pixels=50, y_pixels=25,
+                                 xlim=(-kernel.get_radius(), kernel.get_radius()),
+                                 ylim=(-kernel.get_radius(), kernel.get_radius()))
+    image_vec = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x_pixels=50, y_pixels=25,
+                                         xlim=(-kernel.get_radius(), kernel.get_radius()),
+                                         ylim=(-kernel.get_radius(), kernel.get_radius()))
     for y in range(25):
         for x in range(50):
             assert image[y][x] == approx(
@@ -664,9 +672,9 @@ def test_oob_particles(backend):
     real_x = 1 + (np.arange(0, 25) + 0.5) * (1 / 25)
     real_y = 1 + (np.arange(0, 25) + 0.5) * (1 / 25)
 
-    image = interpolate_2d(sdf_2, 'A', x_pixels=25, y_pixels=25, x_min=1, x_max=2, y_min=1, y_max=2)
-    image_vec = interpolate_2d_vec(sdf_2, 'A', 'B', x_pixels=25, y_pixels=25, x_min=1, x_max=2, y_min=1, y_max=2)
-    line = interpolate_2d_cross(sdf_2, 'A', pixels=25, x1=1, x2=2, y1=1, y2=2)
+    image = interpolate_2d(sdf_2, 'A', x_pixels=25, y_pixels=25, xlim=(1, 2), ylim=(1, 2))
+    image_vec = interpolate_2d_vec(sdf_2, 'A', 'B', x_pixels=25, y_pixels=25, xlim=(1, 2), ylim=(1, 2))
+    line = interpolate_2d_cross(sdf_2, 'A', pixels=25, xlim=(1, 2), ylim=(1, 2))
     for y in range(25):
         assert line[y] == approx(
             w[0] * sdf_2['A'][0] * kernel.w(np.sqrt(real_x[y] ** 2 + real_y[y] ** 2) / sdf_2['h'][0], 2))
@@ -680,8 +688,8 @@ def test_oob_particles(backend):
 
     column_func = kernel.get_column_kernel_func(1000)
 
-    image = interpolate_3d(sdf_3, 'A', x_pixels=25, y_pixels=25, x_min=1, x_max=2, y_min=1, y_max=2)
-    image_vec = interpolate_3d_vec(sdf_3, 'A', 'B', 'C', x_pixels=25, y_pixels=25, x_min=1, x_max=2, y_min=1, y_max=2)
+    image = interpolate_3d(sdf_3, 'A', x_pixels=25, y_pixels=25, xlim=(1, 2), ylim=(1, 2))
+    image_vec = interpolate_3d_vec(sdf_3, 'A', 'B', 'C', x_pixels=25, y_pixels=25, xlim=(1, 2), ylim=(1, 2))
     for y in range(25):
         for x in range(25):
             assert image[y][x] == approx(
@@ -694,9 +702,8 @@ def test_oob_particles(backend):
     # Weight for 3D cross-sections.
     w = sdf_3['m'] / (sdf_3['rho'] * sdf_3['h'] ** 3)
 
-    image = interpolate_3d_cross(sdf_3, 'A', 0, x_pixels=25, y_pixels=25, x_min=1, x_max=2, y_min=1, y_max=2)
-    image_vec = interpolate_3d_cross_vec(sdf_3, 'A', 'B', 'C', 0, x_pixels=25, y_pixels=25, x_min=1, x_max=2, y_min=1,
-                                         y_max=2)
+    image = interpolate_3d_cross(sdf_3, 'A', z_slice=0, x_pixels=25, y_pixels=25, xlim=(1, 2), ylim=(1, 2))
+    image_vec = interpolate_3d_cross_vec(sdf_3, 'A', 'B', 'C', 0, x_pixels=25, y_pixels=25, xlim=(1, 2), ylim=(1, 2))
     for y in range(25):
         for x in range(25):
             assert image[y][x] == approx(
@@ -753,14 +760,14 @@ def test_nonstandard_rotation(backend):
 
     rot_z, rot_y, rot_x = 129, 34, 50
 
-    image_col = interpolate_3d(sdf, 'A', x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1,
+    image_col = interpolate_3d(sdf, 'A', x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1),
                                rotation=[rot_z, rot_y, rot_x], origin=[0, 0, 0])
-    image_cross = interpolate_3d_cross(sdf, 'A', 0, x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1,
-                                       rotation=[rot_z, rot_y, rot_x], origin=[0, 0, 0])
-    image_colvec = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1,
-                                      y_max=1, rotation=[rot_z, rot_y, rot_x], origin=[0, 0, 0])
-    image_crossvec = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x_pixels=50, y_pixels=50, x_min=-1, x_max=1,
-                                              y_min=-1, y_max=1, rotation=[rot_z, rot_y, rot_x], origin=[0, 0, 0])
+    image_cross = interpolate_3d_cross(sdf, 'A', z_slice=0, rotation=[rot_z, rot_y, rot_x], origin=[0, 0, 0],
+                                       x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1))
+    image_colvec = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1),
+                                      rotation=[rot_z, rot_y, rot_x], origin=[0, 0, 0])
+    image_crossvec = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x_pixels=50, y_pixels=50, xlim=(-1, 1),
+                                              ylim=(-1, 1), rotation=[rot_z, rot_y, rot_x], origin=[0, 0, 0])
 
     w_col = sdf['m'] / (sdf['rho'] * sdf['h'] ** 2)
     w_cross = sdf['m'] / (sdf['rho'] * sdf['h'] ** 3)
@@ -801,31 +808,31 @@ def test_scipy_rotation_equivalency(backend):
 
     rot_z, rot_y, rot_x = 67, -34, 91
 
-    image1 = interpolate_3d(sdf, 'A', x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1,
+    image1 = interpolate_3d(sdf, 'A', x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1),
                             rotation=[rot_z, rot_y, rot_x], origin=[0, 0, 0])
-    image2 = interpolate_3d(sdf, 'A', x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1,
+    image2 = interpolate_3d(sdf, 'A', x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1),
                             rotation=Rotation.from_euler('zyx', [rot_z, rot_y, rot_x], degrees=True), origin=[0, 0, 0])
     assert_allclose(image1, image2)
 
-    image1 = interpolate_3d_cross(sdf, 'A', 0, x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1,
-                                  rotation=[rot_z, rot_y, rot_x], origin=[0, 0, 0])
-    image2 = interpolate_3d_cross(sdf, 'A', 0, x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1,
+    image1 = interpolate_3d_cross(sdf, 'A', z_slice=0, rotation=[rot_z, rot_y, rot_x], origin=[0, 0, 0], x_pixels=50,
+                                  y_pixels=50, xlim=(-1, 1), ylim=(-1, 1))
+    image2 = interpolate_3d_cross(sdf, 'A', z_slice=0,
                                   rotation=Rotation.from_euler('zyx', [rot_z, rot_y, rot_x], degrees=True),
-                                  origin=[0, 0, 0])
+                                  origin=[0, 0, 0], x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1))
     assert_allclose(image1, image2)
 
-    image1 = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1,
+    image1 = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1),
                                   rotation=[rot_z, rot_y, rot_x], origin=[0, 0, 0])
-    image2 = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1,
+    image2 = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1),
                                   rotation=Rotation.from_euler('zyx', [rot_z, rot_y, rot_x], degrees=True),
                                   origin=[0, 0, 0])
     assert_allclose(image1[0], image2[0])
     assert_allclose(image1[1], image2[1])
 
-    image1 = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1,
-                                      y_max=1, rotation=[rot_z, rot_y, rot_x], origin=[0, 0, 0])
-    image2 = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1,
-                                      y_max=1, rotation=Rotation.from_euler('zyx', [rot_z, rot_y, rot_x], degrees=True),
+    image1 = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1),
+                                      rotation=[rot_z, rot_y, rot_x], origin=[0, 0, 0])
+    image2 = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1),
+                                      rotation=Rotation.from_euler('zyx', [rot_z, rot_y, rot_x], degrees=True),
                                       origin=[0, 0, 0])
     assert_allclose(image1[0], image2[0])
     assert_allclose(image1[1], image2[1])
@@ -846,14 +853,14 @@ def test_quaternion_rotation(backend):
     column_kernel = kernel.get_column_kernel_func(1000)
 
     quat = Rotation.from_quat([5, 3, 8, 1])
-    image_col = interpolate_3d(sdf, 'A', x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1, rotation=quat,
+    image_col = interpolate_3d(sdf, 'A', x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1), rotation=quat,
                                origin=[0, 0, 0])
-    image_colvec = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1,
-                                      y_max=1, rotation=quat, origin=[0, 0, 0])
-    image_cross = interpolate_3d_cross(sdf, 'A', 0, x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1,
-                                       rotation=quat, origin=[0, 0, 0])
-    image_crossvec = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x_pixels=50, y_pixels=50, x_min=-1, x_max=1,
-                                              y_min=-1, y_max=1, rotation=quat, origin=[0, 0, 0])
+    image_colvec = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1),
+                                      rotation=quat, origin=[0, 0, 0])
+    image_cross = interpolate_3d_cross(sdf, 'A', z_slice=0, rotation=quat, origin=[0, 0, 0], x_pixels=50, y_pixels=50,
+                                       xlim=(-1, 1), ylim=(-1, 1))
+    image_crossvec = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x_pixels=50, y_pixels=50, xlim=(-1, 1),
+                                              ylim=(-1, 1), rotation=quat, origin=[0, 0, 0])
 
     w_col = sdf['m'] / (sdf['rho'] * sdf['h'] ** 2)
     w_cross = sdf['m'] / (sdf['rho'] * sdf['h'] ** 3)
@@ -898,8 +905,8 @@ def test_rotation_stability(backend):
     pixel_x, pixel_y = 12, 30
 
     for func in [interpolate_3d, interpolate_3d_cross]:
-        image = func(sdf, 'A', x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1)
-        image_rot = func(sdf, 'A', x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1, rotation=[237, 0, 0],
+        image = func(sdf, 'A', x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1))
+        image_rot = func(sdf, 'A', x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1), rotation=[237, 0, 0],
                          origin=[real[pixel_x], real[pixel_y], 0])
 
         assert image[pixel_y][pixel_x] == approx(image_rot[pixel_y][pixel_x])
@@ -916,29 +923,28 @@ def test_axes_rotation_separation(backend):
     sdf = SarracenDataFrame(df, params=dict())
     sdf.backend = backend
 
-    image1 = interpolate_3d(sdf, 'A', x_pixels=50,  y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1,
-                            rotation=[234, 90, 48])
-    image2 = interpolate_3d(sdf, 'A', x='y', y='x', x_pixels=50,  y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1,
+    image1 = interpolate_3d(sdf, 'A', x_pixels=50,  y_pixels=50, xlim=(-1, 1), ylim=(-1, 1), rotation=[234, 90, 48])
+    image2 = interpolate_3d(sdf, 'A', x='y', y='x', x_pixels=50,  y_pixels=50, xlim=(-1, 1), ylim=(-1, 1),
                             rotation=[234, 90, 48])
     assert_allclose(image1, image2.T)
 
-    image1 = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1,
-                            rotation=[234, 90, 48])
-    image2 = interpolate_3d_vec(sdf, 'A', 'B', 'C', x='y', y='x', x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1,
-                                y_max=1, rotation=[234, 90, 48])
+    image1 = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1),
+                                rotation=[234, 90, 48])
+    image2 = interpolate_3d_vec(sdf, 'A', 'B', 'C', x='y', y='x', x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1),
+                                rotation=[234, 90, 48])
     assert_allclose(image1[0], image2[0].T)
     assert_allclose(image1[1], image2[1].T)
 
-    image1 = interpolate_3d_cross(sdf, 'A', 0, x_pixels=50,  y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1,
-                                  rotation=[234, 90, 48])
-    image2 = interpolate_3d_cross(sdf, 'A', 0, x='y', y='x', x_pixels=50,  y_pixels=50, x_min=-1, x_max=1, y_min=-1,
-                                  y_max=1,rotation=[234, 90, 48])
+    image1 = interpolate_3d_cross(sdf, 'A', z_slice=0, rotation=[234, 90, 48], x_pixels=50, y_pixels=50, xlim=(-1, 1),
+                                  ylim=(-1, 1))
+    image2 = interpolate_3d_cross(sdf, 'A', x='y', y='x', z_slice=0, rotation=[234, 90, 48], x_pixels=50, y_pixels=50,
+                                  xlim=(-1, 1), ylim=(-1, 1))
     assert_allclose(image1, image2.T)
 
-    image1 = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1,
-                                      y_max=1, rotation=[234, 90, 48])
-    image2 = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x='y', y='x', x_pixels=50, y_pixels=50, x_min=-1, x_max=1,
-                                      y_min=-1, y_max=1, rotation=[234, 90, 48])
+    image1 = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1),
+                                      rotation=[234, 90, 48])
+    image2 = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', 0, x='y', y='x', x_pixels=50, y_pixels=50, xlim=(-1, 1),
+                                      ylim=(-1, 1), rotation=[234, 90, 48])
     assert_allclose(image1[0], image2[0].T)
     assert_allclose(image1[1], image2[1].T)
 
@@ -963,10 +969,9 @@ def test_axes_rotation_equivalency(backend):
                 rot_x, rot_y, rot_z = i_x * 90, i_y * 90, i_z * 90
 
                 for func in [interpolate_3d, interpolate_3d_cross]:
-                    image1 = func(sdf, 'A', x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1,
-                                            rotation=[rot_z, rot_y, rot_x], origin=[0, 0, 0])
-                    image2 = func(sdf, 'A', x=x, y=y, x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1,
-                                            y_max=1)
+                    image1 = func(sdf, 'A', x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1),
+                                  rotation=[rot_z, rot_y, rot_x], origin=[0, 0, 0])
+                    image2 = func(sdf, 'A', x=x, y=y, x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1))
                     image2 = image2 if not flip_x else np.flip(image2, 1)
                     image2 = image2 if not flip_y else np.flip(image2, 0)
                     assert_allclose(image1, image2)
@@ -995,25 +1000,25 @@ def test_invalid_region(backend):
 
     for b in [(-3, 3, 3, -3, 20, 20), (3, 3, 3, 3, 20, 20), (-3, 3, -3, 3, 0, 0)]:
         with raises(ValueError):
-            interpolate_2d(sdf_2, 'A', x_min=b[0], x_max=b[1], y_min=b[2], y_max=b[3], x_pixels=b[4], y_pixels=b[5])
+            interpolate_2d(sdf_2, 'A', xlim=(b[0], b[1]), ylim=(b[2], b[3]), x_pixels=b[4], y_pixels=b[5])
         with raises(ValueError):
-            interpolate_2d_vec(sdf_2, 'A', 'B', 'C', x_min=b[0], x_max=b[1], y_min=b[2], y_max=b[3], x_pixels=b[4],
+            interpolate_2d_vec(sdf_2, 'A', 'B', 'C', xlim=(b[0], b[1]), ylim=(b[2], b[3]), x_pixels=b[4],
                                y_pixels=b[5])
         # the first case will not fail for this type of interpolation.
         if not b[0] == -3 and not b[3] == -3:
             with raises(ValueError):
-                interpolate_2d_cross(sdf_2, 'A', x1=b[0], x2=b[1], y1=b[2], y2=b[3], pixels=b[4])
+                interpolate_2d_cross(sdf_2, 'A', xlim=(b[0], b[1]), ylim=(b[2], b[3]), pixels=b[4])
         with raises(ValueError):
-            interpolate_3d(sdf_3, 'A', x_min=b[0], x_max=b[1], y_min=b[2], y_max=b[3], x_pixels=b[4], y_pixels=b[5])
+            interpolate_3d(sdf_3, 'A', xlim=(b[0], b[1]), ylim=(b[2], b[3]), x_pixels=b[4], y_pixels=b[5])
         with raises(ValueError):
-            interpolate_3d_vec(sdf_3, 'A', 'B', 'C', x_min=b[0], x_max=b[1], y_min=b[2], y_max=b[3], x_pixels=b[4],
+            interpolate_3d_vec(sdf_3, 'A', 'B', 'C', xlim=(b[0], b[1]), ylim=(b[2], b[3]), x_pixels=b[4],
                                y_pixels=b[5])
         with raises(ValueError):
-            interpolate_3d_cross(sdf_3, 'A', 0, x_min=b[0], x_max=b[1], y_min=b[2], y_max=b[3], x_pixels=b[4],
-                                 y_pixels=b[5])
+            interpolate_3d_cross(sdf_3, 'A', z_slice=0, x_pixels=b[4], y_pixels=b[5], xlim=(b[0], b[1]),
+                                 ylim=(b[2], b[3]))
         with raises(ValueError):
-            interpolate_3d_cross_vec(sdf_3, 'A', 'B', 'C', 0, x_min=b[0], x_max=b[1], y_min=b[2], y_max=b[3],
-                                     x_pixels=b[4], y_pixels=b[5])
+            interpolate_3d_cross_vec(sdf_3, 'A', 'B', 'C', 0, xlim=(b[0], b[1]), ylim=(b[2], b[3]), x_pixels=b[4],
+                                     y_pixels=b[5])
 
 
 @mark.parametrize("backend", backends)
@@ -1069,10 +1074,10 @@ def test_exact_interpolation(backend):
     w = sdf_2['m'] * sdf_2['A'] / (sdf_2['rho'] * sdf_2['h'] ** 2)
 
     bound = kernel.get_radius() * sdf_2['h'][0]
-    image = interpolate_2d(sdf_2, 'A', x_min=-bound, x_max=bound, y_min=-bound, y_max=bound, x_pixels=1, exact=True)
+    image = interpolate_2d(sdf_2, 'A', xlim=(-bound, bound), ylim=(-bound, bound), x_pixels=1, exact=True)
 
     assert image.sum() == approx(w[0] * sdf_2['h'][0] ** 2 / (4 * bound ** 2))
 
-    image = interpolate_3d(sdf_3, 'A', x_min=-bound, x_max=bound, y_min=-bound, y_max=bound, x_pixels=1, exact=True)
+    image = interpolate_3d(sdf_3, 'A', xlim=(-bound, bound), ylim=(-bound, bound), x_pixels=1, exact=True)
 
     assert image.sum() == approx(w[0] * sdf_2['h'][0] ** 2 / (4 * bound ** 2))

--- a/sarracen/tests/test_render.py
+++ b/sarracen/tests/test_render.py
@@ -27,8 +27,8 @@ def test_interpolation_passthrough(backend):
     assert_array_equal(ax.images[0].get_array().filled(0), interpolate_2d(sdf, 'P'))
 
     fig, ax = plt.subplots()
-    render(sdf, 'P', xsec=True, x1=3, x2=6, y1=5, y2=1, ax=ax)
-    assert_array_equal(ax.lines[0].get_ydata(), interpolate_2d_cross(sdf, 'P', x1=3, x2=6, y1=5, y2=1))
+    render(sdf, 'P', xsec=True, xlim=(3, 6), ylim=(5, 1), ax=ax)
+    assert_array_equal(ax.lines[0].get_ydata(), interpolate_2d_cross(sdf, 'P', xlim=(3, 6), ylim=(5, 1)))
 
     df = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf = SarracenDataFrame(df)
@@ -53,7 +53,7 @@ def test_cmap(backend):
     sdf.backend = backend
 
     fig, ax = plt.subplots()
-    render(sdf, 'P', ax=ax, cmap='magma')
+    render(sdf, 'P', cmap='magma', ax=ax)
 
     assert ax.images[0].cmap.name == 'magma'
 
@@ -84,14 +84,14 @@ def test_cbar_exclusion(backend):
     sdf_3 = SarracenDataFrame(df_3)
     sdf_3.backend = backend
 
-    for args in [{'data': sdf_2, 'xsec': False}, {'data': sdf_3, 'xsec': False}, {'data': sdf_3, 'xsec': True}]:
+    for args in [{'data': sdf_2, 'xsec': None}, {'data': sdf_3, 'xsec': None}, {'data': sdf_3, 'xsec': True}]:
         fig, ax = plt.subplots()
-        render(args['data'], 'P', xsec=args['xsec'], ax=ax, cbar=True)
+        render(args['data'], 'P', xsec=args['xsec'], cbar=True, ax=ax)
 
         assert ax.images[-1].colorbar is not None
 
         fig, ax = plt.subplots()
-        render(args['data'], 'P', xsec=args['xsec'], ax=ax, cbar=False)
+        render(args['data'], 'P', xsec=args['xsec'], cbar=False, ax=ax)
 
         assert ax.images[-1].colorbar is None
 
@@ -108,9 +108,9 @@ def test_cbar_keywords(backend):
     sdf_3 = SarracenDataFrame(df_3)
     sdf_3.backend = backend
 
-    for args in [{'data': sdf_2, 'xsec': False}, {'data': sdf_3, 'xsec': False}, {'data': sdf_3, 'xsec': True}]:
+    for args in [{'data': sdf_2, 'xsec': None}, {'data': sdf_3, 'xsec': None}, {'data': sdf_3, 'xsec': True}]:
         fig, ax = plt.subplots()
-        render(args['data'], 'P', xsec=args['xsec'], ax=ax, cbar_kws={'orientation': 'horizontal'})
+        render(args['data'], 'P', xsec=args['xsec'], cbar_kws={'orientation': 'horizontal'}, ax=ax)
 
         assert ax.images[-1].colorbar.orientation == 'horizontal'
 
@@ -128,7 +128,7 @@ def test_kwargs(backend):
     sdf_3 = SarracenDataFrame(df_3)
     sdf_3.backend = backend
 
-    for args in [{'data': sdf_2, 'xsec': False}, {'data': sdf_3, 'xsec': False}, {'data': sdf_3, 'xsec': True}]:
+    for args in [{'data': sdf_2, 'xsec': None}, {'data': sdf_3, 'xsec': None}, {'data': sdf_3, 'xsec': True}]:
         fig, ax = plt.subplots()
         render(args['data'], 'P', xsec=args['xsec'], ax=ax, origin='upper')
 
@@ -143,7 +143,7 @@ def test_kwargs(backend):
     assert ax.collections[0].zorder == 5
 
     fig, ax = plt.subplots()
-    render(sdf_2, 'P', xsec=True, x1=3, x2=6, y1=5, y2=1, ax=ax, linestyle='--')
+    render(sdf_2, 'P', xsec=True, xlim=(3, 6), ylim=(5, 1), ax=ax, linestyle='--')
 
     assert ax.lines[0].get_linestyle() == '--'
 
@@ -160,7 +160,7 @@ def test_rotated_ticks(backend):
 
     for xsec in [False, True]:
         fig, ax = plt.subplots()
-        render(sdf, 'P', xsec=xsec, rotation=[34, 23, 50], ax=ax)
+        render(sdf, 'P', xsec=xsec, ax=ax, rotation=[34, 23, 50])
 
         assert ax.get_xticks().size == 0
         assert ax.get_yticks().size == 0
@@ -188,7 +188,7 @@ def test_plot_labels(backend):
     sdf_3 = SarracenDataFrame(df_3)
     sdf_3.backend = backend
 
-    for args in [{'data': sdf_2, 'xsec': False}, {'data': sdf_3, 'xsec': False}, {'data': sdf_3, 'xsec': True}]:
+    for args in [{'data': sdf_2, 'xsec': None}, {'data': sdf_3, 'xsec': None}, {'data': sdf_3, 'xsec': True}]:
         fig, ax = plt.subplots()
         render(args['data'], 'P', xsec=args['xsec'], ax=ax)
 
@@ -197,7 +197,7 @@ def test_plot_labels(backend):
         assert ax.figure.axes[1].get_ylabel() == ('column ' if args['data'] is sdf_3 and not args['xsec'] else '') + 'P'
 
         fig, ax = plt.subplots()
-        render(args['data'], 'rho', xsec=args['xsec'], x='y', y='x', ax=ax)
+        render(args['data'], 'rho', x='y', y='x', xsec=args['xsec'], ax=ax)
 
         assert ax.get_xlabel() == 'y'
         assert ax.get_ylabel() == 'x'
@@ -224,7 +224,7 @@ def test_plot_labels(backend):
     assert ax.get_ylabel() == 'P'
 
     fig, ax = plt.subplots()
-    render(sdf_2, 'rho', xsec=True, x='y', y='x', ax=ax)
+    render(sdf_2, 'rho', x='y', y='x', xsec=True, ax=ax)
 
     assert ax.get_xlabel() == 'cross-section (y, x)'
     assert ax.get_ylabel() == 'rho'
@@ -244,7 +244,7 @@ def test_plot_bounds(backend):
     sdf_3 = SarracenDataFrame(df_3)
     sdf_3.backend = backend
 
-    for args in [{'data': sdf_2, 'xsec': False}, {'data': sdf_2, 'xsec': False}, {'data': sdf_3, 'xsec': False},
+    for args in [{'data': sdf_2, 'xsec': None}, {'data': sdf_2, 'xsec': True}, {'data': sdf_3, 'xsec': None},
                  {'data': sdf_3, 'xsec': True}]:
         fig, ax = plt.subplots()
         render(args['data'], 'P', xsec=args['xsec'], ax=ax)
@@ -261,7 +261,7 @@ def test_plot_bounds(backend):
             assert ax.get_ylim() == (1, 5)
 
         if args['data'] is sdf_2:
-            if args['xsec']:
+            if not args['xsec']:
                 assert ax.figure.axes[1].get_ylim() == (0, interpolate_2d(sdf_2, 'P').max())
         else:
             if args['xsec']:

--- a/sarracen/tests/test_render.py
+++ b/sarracen/tests/test_render.py
@@ -39,7 +39,7 @@ def test_interpolation_passthrough(backend):
     assert_array_equal(ax.images[0].get_array().filled(0), interpolate_3d(sdf, 'P'))
 
     fig, ax = plt.subplots()
-    render(sdf, 'P', xsec=True, ax=ax)
+    render(sdf, 'P', xsec=1.5, ax=ax)
     assert_array_equal(ax.images[0].get_array().filled(0), interpolate_3d_cross(sdf, 'P'))
 
 
@@ -67,7 +67,7 @@ def test_cmap(backend):
     assert ax.images[0].cmap.name == 'magma'
 
     fig, ax = plt.subplots()
-    render(sdf, 'P', xsec=True, cmap='magma', ax=ax)
+    render(sdf, 'P', xsec=1.5, cmap='magma', ax=ax)
 
     assert ax.images[0].cmap.name == 'magma'
 
@@ -84,7 +84,7 @@ def test_cbar_exclusion(backend):
     sdf_3 = SarracenDataFrame(df_3)
     sdf_3.backend = backend
 
-    for args in [{'data': sdf_2, 'xsec': None}, {'data': sdf_3, 'xsec': None}, {'data': sdf_3, 'xsec': True}]:
+    for args in [{'data': sdf_2, 'xsec': None}, {'data': sdf_3, 'xsec': None}, {'data': sdf_3, 'xsec': 1.5}]:
         fig, ax = plt.subplots()
         render(args['data'], 'P', xsec=args['xsec'], cbar=True, ax=ax)
 
@@ -108,7 +108,7 @@ def test_cbar_keywords(backend):
     sdf_3 = SarracenDataFrame(df_3)
     sdf_3.backend = backend
 
-    for args in [{'data': sdf_2, 'xsec': None}, {'data': sdf_3, 'xsec': None}, {'data': sdf_3, 'xsec': True}]:
+    for args in [{'data': sdf_2, 'xsec': None}, {'data': sdf_3, 'xsec': None}, {'data': sdf_3, 'xsec': 1.5}]:
         fig, ax = plt.subplots()
         render(args['data'], 'P', xsec=args['xsec'], cbar_kws={'orientation': 'horizontal'}, ax=ax)
 
@@ -128,7 +128,7 @@ def test_kwargs(backend):
     sdf_3 = SarracenDataFrame(df_3)
     sdf_3.backend = backend
 
-    for args in [{'data': sdf_2, 'xsec': None}, {'data': sdf_3, 'xsec': None}, {'data': sdf_3, 'xsec': True}]:
+    for args in [{'data': sdf_2, 'xsec': None}, {'data': sdf_3, 'xsec': None}, {'data': sdf_3, 'xsec': 1.5}]:
         fig, ax = plt.subplots()
         render(args['data'], 'P', xsec=args['xsec'], ax=ax, origin='upper')
 
@@ -158,7 +158,7 @@ def test_rotated_ticks(backend):
     sdf = SarracenDataFrame(df)
     sdf.backend = backend
 
-    for xsec in [False, True]:
+    for xsec in [None, 1.5]:
         fig, ax = plt.subplots()
         render(sdf, 'P', xsec=xsec, ax=ax, rotation=[34, 23, 50])
 
@@ -245,8 +245,7 @@ def test_plot_bounds(backend):
     sdf_3 = SarracenDataFrame(df_3)
     sdf_3.backend = backend
 
-    for args in [{'data': sdf_2, 'xsec': None}, {'data': sdf_2, 'xsec': True}, {'data': sdf_3, 'xsec': None},
-                 {'data': sdf_3, 'xsec': True}]:
+    for args in [{'data': sdf_2, 'xsec': None}, {'data': sdf_3, 'xsec': None}, {'data': sdf_3, 'xsec': 1.5}]:
         fig, ax = plt.subplots()
         render(args['data'], 'P', xsec=args['xsec'], ax=ax)
 

--- a/sarracen/tests/test_sarracen_dataframe.py
+++ b/sarracen/tests/test_sarracen_dataframe.py
@@ -2,7 +2,7 @@
 import pandas as pd
 from matplotlib import pyplot as plt
 
-from sarracen import SarracenDataFrame, render_2d, render_2d_cross, render_3d, render_3d_cross
+from sarracen import SarracenDataFrame, render
 
 
 def test_special_columns():
@@ -114,15 +114,15 @@ def test_render_passthrough():
 
     fig1, ax1 = plt.subplots()
     fig2, ax2 = plt.subplots()
-    ax1 = sdf.render_2d('P', ax=ax1)
-    ax2 = render_2d(sdf, 'P', ax=ax2)
+    ax1 = sdf.render('P', ax=ax1)
+    ax2 = render(sdf, 'P', ax=ax2)
 
     assert repr(ax1) == repr(ax2)
 
     fig1, ax1 = plt.subplots()
     fig2, ax2 = plt.subplots()
-    ax1 = sdf.render_2d_cross('P', ax=ax1)
-    ax2 = render_2d_cross(sdf, 'P', ax=ax2)
+    ax1 = sdf.render('P', xsec=True, ax=ax1)
+    ax2 = render(sdf, 'P', xsec=True, ax=ax2)
 
     assert repr(ax1) == repr(ax2)
 
@@ -133,14 +133,14 @@ def test_render_passthrough():
 
     fig1, ax1 = plt.subplots()
     fig2, ax2 = plt.subplots()
-    ax1 = sdf.render_3d('P', ax=ax1)
-    ax2 = render_3d(sdf, 'P', ax=ax2)
+    ax1 = sdf.render('P', ax=ax1)
+    ax2 = render(sdf, 'P', ax=ax2)
 
     assert repr(ax1) == repr(ax2)
 
     fig1, ax1 = plt.subplots()
     fig2, ax2 = plt.subplots()
-    ax1 = sdf.render_3d_cross('P', ax=ax1)
-    ax2 = render_3d_cross(sdf, 'P', ax=ax2)
+    ax1 = sdf.render('P', xsec=True, ax=ax1)
+    ax2 = render(sdf, 'P', xsec=True, ax=ax2)
 
     assert repr(ax1) == repr(ax2)


### PR DESCRIPTION
Previously, scalar rendering was split into four different functions (`render_2d`, `render_2d_cross`, `render_3d`, `render_3d_cross`). The user would have to pick which one to choose based off the type of dataset they were using, and whether they want to perform a cross-section or not. These four functions have been merged into one function (`render`) for ease of use. The specific kind of interpolation and rendering used depends on the arguments and the type of data supplied to the function.

Now, the user has access to three different rendering functions overall: `render`, `streamlines`, and `arrowplot`.