### PR TITLE
Add support for arrowplot quiver keys

### DIFF
--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -369,8 +369,6 @@ def arrowplot(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[st
         If `target`, `x`, `y`, `z` (for 3-dimensional data), mass, density, or smoothing length columns do not
         exist in `data`.
     """
-    if qkey_kws is None:
-        qkey_kws = {}
     x, y = _default_axes(data, x, y)
     x_min, x_max, y_min, y_max = _default_bounds(data, x, y, x_min, x_max, y_min, y_max)
     x_arrows, y_arrows = _set_pixels(x_arrows, y_arrows, x_min, x_max, y_min, y_max, 20)

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -417,7 +417,7 @@ def arrowplot(data: 'SarracenDataFrame', target: Union[Tuple[str, str], Tuple[st
         key_length = float(np.format_float_positional(np.mean(np.sqrt(img[0] ** 2 + img[1] ** 2)), precision=1,
                                                       unique=False, fractional=False, trim='k'))
         qkey_kws.setdefault('U', key_length)
-        qkey_kws.setdefault('label', f"= {key_length}")
+        qkey_kws.setdefault('label', f"= {qkey_kws['U']}")
 
         qkey_kws.setdefault('labelpos', 'E')
         qkey_kws.setdefault('coordinates', 'axes')

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -201,9 +201,10 @@ class SarracenDataFrame(DataFrame):
                   y: str = None, z: str = None, kernel: BaseKernel = None, integral_samples: int = 1000,
                   rotation: np.ndarray = None, rot_origin: np.ndarray = None, x_arrows: int = None,
                   y_arrows: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
-                  y_max: float = None, ax: Axes = None, exact: bool = None, backend: str='cpu', **kwargs) -> Axes:
+                  y_max: float = None, ax: Axes = None, qkey: bool = True, qkey_kws: dict = None, exact: bool = None,
+                  backend: str='cpu', **kwargs) -> Axes:
         return arrowplot(self, target, z_slice, x, y, z, kernel, integral_samples, rotation, rot_origin, x_arrows,
-                         y_arrows, x_min, x_max, y_min, y_max, ax, exact, backend, **kwargs)
+                         y_arrows, x_min, x_max, y_min, y_max, ax, qkey, qkey_kws, exact, backend, **kwargs)
 
     @property
     def params(self):


### PR DESCRIPTION
Add a key to `arrowplot` generated images, which displays the magnitude of the target vector that each arrow represents. The properties of this key can be altered with the arguments `qkey` and `qkey_kws`.

Example:
![image](https://user-images.githubusercontent.com/71343838/180479896-80e57f51-b79d-4b99-8798-150c8448e906.png)

Generated with: (`sdf` contains vortex data)
```
fig, ax = plt.subplots(figsize=(9, 9))
sdf.render_2d('rho', x_pixels=1000, ax=ax, cmap='viridis')
sdf.arrowplot(('bx', 'by'), x_arrows=30, exact=True, ax=ax, qkey_kws={'X': 0.9, 'U': 0.05})
ax.set_title("Orszag-Tang Vortex with Magnetic Field")
plt.show()
```