### PR TITLE
Add support for logarithmic plotting

### DIFF
--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -153,17 +153,18 @@ class SarracenDataFrame(DataFrame):
     def render_2d(self, target: str, x: str = None, y: str = None, kernel: BaseKernel = None, x_pixels: int = None,
                   y_pixels: int = None, x_min: float = None, x_max: float = None, y_min: float = None,
                   y_max: float = None, cmap: Union[str, Colormap] = 'RdBu', cbar: bool = True, cbar_kws: dict = {},
-                  cbar_ax: Axes = None, ax: Axes = None, exact: bool = None, backend: str = None, **kwargs) -> Axes:
+                  cbar_ax: Axes = None, ax: Axes = None, exact: bool = None, backend: str = None, log_scale: bool = None,
+                  **kwargs) -> Axes:
 
         return render_2d(self, target, x, y, kernel, x_pixels, y_pixels, x_min, x_max, y_min, y_max, cmap, cbar,
-                         cbar_kws, cbar_ax, ax, exact, backend, **kwargs)
+                         cbar_kws, cbar_ax, ax, exact, backend, log_scale, **kwargs)
 
     @_copy_doc(render_2d_cross)
     def render_2d_cross(self, target: str, x: str = None, y: str = None, kernel: BaseKernel = None, pixels: int = 512,
                         x1: float = None, y1: float = None, x2: float = None, y2: float = None, ax: Axes = None,
-                        backend: str = None, **kwargs) -> Axes:
+                        backend: str = None, log_scale: bool = None, **kwargs) -> Axes:
 
-        return render_2d_cross(self, target, x, y, kernel, pixels, x1, x2, y1, y2, ax, backend, **kwargs)
+        return render_2d_cross(self, target, x, y, kernel, pixels, x1, x2, y1, y2, ax, backend, log_scale, **kwargs)
 
     @_copy_doc(render_3d)
     def render_3d(self, target: str, x: str = None, y: str = None, kernel: BaseKernel = None,
@@ -171,10 +172,10 @@ class SarracenDataFrame(DataFrame):
                   x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None,
                   y_min: float = None, y_max: float = None, cmap: Union[str, Colormap] = 'RdBu', cbar: bool = True,
                   cbar_kws: dict = {}, cbar_ax: Axes = None, ax: Axes = None, exact: bool = None, backend: str = None,
-                  **kwargs) -> Axes:
+                  log_scale: bool = None, **kwargs) -> Axes:
 
         return render_3d(self, target, x, y, kernel, int_samples, rotation, rot_origin, x_pixels, y_pixels, x_min,
-                         x_max, y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, exact, backend, **kwargs)
+                         x_max, y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, exact, backend, log_scale, **kwargs)
 
     @_copy_doc(render_3d_cross)
     def render_3d_cross(self, target: str, z_slice: float = None, x: str = None, y: str = None, z: str = None,
@@ -182,10 +183,10 @@ class SarracenDataFrame(DataFrame):
                         x_pixels: int = None, y_pixels: int = None, x_min: float = None, x_max: float = None,
                         y_min: float = None, y_max: float = None, cmap: Union[str, Colormap] = 'RdBu',
                         cbar: bool = True, cbar_kws: dict = {}, cbar_ax: Axes = None, ax: Axes = None,
-                        backend: str = None, **kwargs) -> Axes:
+                        backend: str = None, log_scale: bool = None, **kwargs) -> Axes:
 
         return render_3d_cross(self, target, z_slice, x, y, z, kernel, rotation, rot_origin, x_pixels, y_pixels, x_min,
-                               x_max, y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, backend, **kwargs)
+                               x_max, y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, backend, log_scale, **kwargs)
 
     @_copy_doc(streamlines)
     def streamlines(self, target: Union[Tuple[str, str], Tuple[str, str, str]], z_slice: int = None, x: str = None,


### PR DESCRIPTION
Adds support for logarithmic scaling in the scalar rendering functions (`render_2d_cross`, `render_2d`, `render_3d_cross`, `render_3d`). For `render_2d_cross` the y-axis is scaled logarithmically, while the logarithmic scale is applied to the color scale for the other rendering methods.

Example:

![image](https://user-images.githubusercontent.com/71343838/180503261-0a0d73c1-9bfc-43c8-a2f2-6d57a8bfb212.png)
