### PR TITLE
Interpolation of 3D data to a 3D grid

### DIFF
--- a/sarracen/interpolate/__init__.py
+++ b/sarracen/interpolate/__init__.py
@@ -2,4 +2,4 @@ from sarracen.interpolate.base_backend import BaseBackend
 from sarracen.interpolate.cpu_backend import CPUBackend
 from sarracen.interpolate.gpu_backend import GPUBackend
 from sarracen.interpolate.interpolate import interpolate_2d_cross, interpolate_2d, interpolate_3d,\
-    interpolate_3d_cross, interpolate_3d_vec, interpolate_3d_cross_vec, interpolate_2d_vec
+    interpolate_3d_cross, interpolate_3d_vec, interpolate_3d_cross_vec, interpolate_3d_grid, interpolate_2d_vec

--- a/sarracen/interpolate/base_backend.py
+++ b/sarracen/interpolate/base_backend.py
@@ -62,3 +62,13 @@ class BaseBackend:
         specific z value.
         """
         return zeros((y_pixels, x_pixels)), zeros((y_pixels, x_pixels))
+
+    @staticmethod
+    def interpolate_3d_grid(x: ndarray, y: ndarray, z: ndarray, weight: ndarray, h: ndarray,
+                            weight_function: CPUDispatcher, kernel_radius: float, x_pixels: int, y_pixels: int,
+                            z_pixels: int, x_min: float, x_max: float, y_min: float, y_max: float, z_min: float,
+                            z_max: float) -> ndarray:
+        """
+        Interpolate 3D particle data to a 3D grid of pixels.
+        """
+        return zeros((z_pixels, y_pixels, x_pixels))

--- a/sarracen/interpolate/cpu_backend.py
+++ b/sarracen/interpolate/cpu_backend.py
@@ -77,6 +77,22 @@ class CPUBackend(BaseBackend):
                 CPUBackend._fast_2d(z_slice, x, y, z, weight_y, h, weight_function, kernel_radius, x_pixels, y_pixels,
                                     x_min, x_max, y_min, y_max, 3))
 
+    @staticmethod
+    def interpolate_3d_grid(x: ndarray, y: ndarray, z: ndarray, weight: ndarray, h: ndarray,
+                            weight_function: CPUDispatcher, kernel_radius: float, x_pixels: int, y_pixels: int,
+                            z_pixels: int, x_min: float, x_max: float, y_min: float, y_max: float, z_min: float,
+                            z_max: float) -> ndarray:
+        image = np.zeros((z_pixels, y_pixels, x_pixels))
+        pixwidthz = (z_max - z_min) / z_pixels
+
+        for z_i in np.arange(z_pixels):
+            z_val = z_min + (z_i + 0.5) * pixwidthz
+            image[z_i] = CPUBackend._fast_2d(z_val, x, y, z, weight, h, weight_function, kernel_radius, x_pixels,
+                                             y_pixels, x_min, x_max, y_min, y_max, 3)
+
+        return image
+
+
     # Underlying CPU numba-compiled code for interpolation to a 2D grid. Used in interpolation of 2D data,
     # and column integration / cross-sections of 3D data.
     @staticmethod

--- a/sarracen/interpolate/gpu_backend.py
+++ b/sarracen/interpolate/gpu_backend.py
@@ -78,6 +78,22 @@ class GPUBackend(BaseBackend):
                 GPUBackend._fast_2d(z_slice, x, y, z, weight_y, h, weight_function, kernel_radius, x_pixels, y_pixels,
                                     x_min, x_max, y_min, y_max, 3))
 
+    @staticmethod
+    def interpolate_3d_grid(x: ndarray, y: ndarray, z: ndarray, weight: ndarray, h: ndarray,
+                            weight_function: CPUDispatcher, kernel_radius: float, x_pixels: int, y_pixels: int,
+                            z_pixels: int, x_min: float, x_max: float, y_min: float, y_max: float, z_min: float,
+                            z_max: float) -> ndarray:
+        image = np.zeros((z_pixels, y_pixels, x_pixels))
+        pixwidthz = (z_max - z_min) / z_pixels
+
+        # todo: this should be separated from _fast_2d to reduce the unnecessary transfer of data to the graphics card.
+        for z_i in np.arange(z_pixels):
+            z_val = z_min + (z_i + 0.5) * pixwidthz
+            image[z_i] = GPUBackend._fast_2d(z_val, x, y, z, weight, h, weight_function, kernel_radius, x_pixels,
+                                             y_pixels, x_min, x_max, y_min, y_max, 3)
+
+        return image
+
     # For the GPU, the numba code is compiled using a factory function approach. This is required
     # since a CUDA numba kernel cannot easily take weight_function as an argument.
     @staticmethod

--- a/sarracen/readers/read_phantom.py
+++ b/sarracen/readers/read_phantom.py
@@ -228,4 +228,5 @@ def read_phantom(filename: str, separate_types: str = 'sinks'):
             return [SarracenDataFrame(df, params={**header_vars, **{"mass": header_vars['massoftype']}}),
                     SarracenDataFrame(df_sinks, params=header_vars)]
 
-        return SarracenDataFrame(pd.concat([df, df_sinks], ignore_index=True), params=header_vars)
+        return SarracenDataFrame(pd.concat([df, df_sinks], ignore_index=True),
+                                 params={**header_vars, **{"mass": header_vars['massoftype']}})

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -6,6 +6,7 @@ from pandas import DataFrame, Series
 import numpy as np
 
 from sarracen.render import render_2d, render_2d_cross, render_3d, render_3d_cross, streamlines, arrowplot
+from sarracen.interpolate import interpolate_2d, interpolate_3d_grid
 from sarracen.kernels import CubicSplineKernel, BaseKernel
 
 
@@ -206,6 +207,68 @@ class SarracenDataFrame(DataFrame):
                   backend: str='cpu', **kwargs) -> Axes:
         return arrowplot(self, target, z_slice, x, y, z, kernel, integral_samples, rotation, rot_origin, x_arrows,
                          y_arrows, x_min, x_max, y_min, y_max, ax, qkey, qkey_kws, exact, backend, **kwargs)
+
+    def sph_interpolate(self, target: str, x: str = None, y: str = None, z: str = None, kernel: BaseKernel = None,
+                        rotation: np.ndarray = None, rot_origin: np.ndarray = None, x_pixels: int = None,
+                        y_pixels: int = None, z_pixels: int = None, xlim: tuple[float, float] = None,
+                        ylim: tuple[float, float] = None, zlim: tuple[float, float] = None,
+                        exact: bool = None, backend: str = 'cpu') -> np.ndarray:
+        """ Interpolate this data to a 2D or 3D grid, depending on the dimensionality of the data.
+
+        Parameters
+        ----------
+        data : SarracenDataFrame
+            The particle data to interpolate over.
+        target: str
+            The column label of the target data.
+        x, y, z: str
+            The column labels of the directional data to interpolate over. Defaults to the x, y, and z columns
+            detected in `data`.
+        kernel: BaseKernel
+            The kernel to use for smoothing the target data. Defaults to the kernel specified in `data`.
+        rotation: array_like or Rotation, optional
+            The rotation to apply to the data before interpolation. If defined as an array, the
+            order of rotations is [z, y, x] in degrees. Only applicable to 3D datasets.
+        rot_origin: array_like, optional
+            Point of rotation of the data, in [x, y, z] form. Defaults to the centre
+            point of the bounds of the data. Only applicable to 3D datasets.
+        x_pixels, y_pixels, z_pixels: int, optional
+            Number of pixels in the output image in the x, y & z directions. Default values are chosen to keep
+            a consistent aspect ratio.
+        xlim, ylim, zlim: tuple of float, optional
+            The minimum and maximum values to use in interpolation, in particle data space. Defaults
+            to the minimum and maximum values of `x`, `y` and `z`.
+        exact: bool
+            Whether to use exact interpolation of the data. Only applies to 2D datasets.
+        backend: ['cpu', 'gpu']
+            The computation backend to use when interpolating this data. Defaults to the backend specified in `data`.
+
+        Returns
+        -------
+        ndarray (n-Dimensional)
+            The interpolated output image, in a multi-dimensional numpy array. The number of dimensions match the
+            dimensions of the data. Dimensions are structured in reverse order, where (x, y, z) -> [z, y, x].
+
+        Raises
+        -------
+        ValueError
+            If `x_pixels`, `y_pixels` or `z_pixels` are less than or equal to zero, or
+            if the specified `x`, `y` and `z` minimum and maximum values result in an invalid region, or
+            if `data` is not 2 or 3 dimensional.
+        KeyError
+            If `target`, `x`, `y`, `z`, mass, density, or smoothing length columns do not
+            exist in `data`.
+        """
+        if self.get_dim() == 2:
+            if xlim is None:
+                xlim = (None, None)
+            if ylim is None:
+                ylim = (None, None)
+            return interpolate_2d(self, target, x, y, kernel, x_pixels, y_pixels, xlim[0], xlim[1], ylim[0], ylim[1],
+                                  exact, backend)
+        elif self.get_dim() == 3:
+            return interpolate_3d_grid(self, target, x, y, z, kernel, rotation, rot_origin, x_pixels, y_pixels,
+                                       z_pixels, xlim, ylim, zlim, backend)
 
     @property
     def params(self):

--- a/sarracen/tests/test_interpolate.py
+++ b/sarracen/tests/test_interpolate.py
@@ -11,7 +11,7 @@ from scipy.spatial.transform import Rotation
 from sarracen import SarracenDataFrame
 from sarracen.kernels import CubicSplineKernel, QuarticSplineKernel, QuinticSplineKernel
 from sarracen.interpolate import interpolate_2d, interpolate_2d_cross, interpolate_3d_cross, interpolate_3d, \
-    interpolate_2d_vec, interpolate_3d_vec, interpolate_3d_cross_vec
+    interpolate_2d_vec, interpolate_3d_vec, interpolate_3d_cross_vec, interpolate_3d_grid
 
 backends = ['cpu']
 if cuda.is_available():
@@ -91,6 +91,17 @@ def test_single_particle(backend):
                                                          / sdf['h'][0], 3))
             assert image_vec[1][y][x] == approx(w[0] * sdf['B'][0] *
                                                 kernel.w(np.sqrt(real[x] ** 2 + real[y] ** 2 + 0.5 ** 2)
+                                                         / sdf['h'][0], 3))
+
+    bounds = (-kernel.get_radius(), kernel.get_radius())
+    image = interpolate_3d_grid(sdf, 'A', x_pixels=25, y_pixels=25, z_pixels=25, xlim=bounds, ylim=bounds,
+                                zlim=bounds)
+
+    for z in range(25):
+        for y in range(25):
+            for x in range(25):
+                assert image[z][y][x] == approx(w[0] * sdf['A'][0] *
+                                                kernel.w(np.sqrt(real[x] ** 2 + real[y] ** 2 + (real[z] + 0.5) ** 2)
                                                          / sdf['h'][0], 3))
 
 
@@ -174,6 +185,16 @@ def test_single_repeated_particle(backend):
                                                 kernel.w(np.sqrt(real[x] ** 2 + real[y] ** 2 + 0.5 ** 2)
                                                          / sdf['h'][0], 3))
 
+    bounds = (-kernel.get_radius(), kernel.get_radius())
+    image = interpolate_3d_grid(sdf, 'A', x_pixels=25, y_pixels=25, z_pixels=25, xlim=bounds, ylim=bounds, zlim=bounds)
+
+    for z in range(25):
+        for y in range(25):
+            for x in range(25):
+                assert image[z][y][x] == approx(w[0] * sdf['A'][0] *
+                                                kernel.w(np.sqrt(real[x] ** 2 + real[y] ** 2 + (real[z] + 0.5) ** 2)
+                                                         / sdf['h'][0], 3))
+
 
 @mark.parametrize("backend", backends)
 def test_dimension_check(backend):
@@ -189,7 +210,7 @@ def test_dimension_check(backend):
     for func in [interpolate_3d, interpolate_3d_cross]:
         with raises(TypeError):
             func(sdf, 'P')
-    for func in [interpolate_3d_vec, interpolate_3d_cross_vec]:
+    for func in [interpolate_3d_vec, interpolate_3d_cross_vec, interpolate_3d_grid]:
         with raises(TypeError):
             func(sdf, 'Ax', 'Ay', 'Az')
 
@@ -354,6 +375,17 @@ def test_corner_particles(backend):
                                                             / sdf_3['h'][1], 3)) == image_vec[1][y][x]
 
 
+    image = interpolate_3d_grid(sdf_3, 'A', x_pixels=25, y_pixels=25, z_pixels=25)
+    for z in range(25):
+        for y in range(25):
+            for x in range(25):
+                assert approx(
+                    w[0] * sdf_3['A'][0] * kernel.w(np.sqrt(real[x] ** 2 + real[y] ** 2 + real[z] ** 2)
+                                                    / sdf_3['h'][0], 3) +
+                    w[1] * sdf_3['A'][1] * kernel.w(np.sqrt(real[24 - x] ** 2 + real[24 - y] ** 2 + real[24 - z] ** 2)
+                                                    / sdf_3['h'][1], 3)) == image[z][y][x]
+
+
 @mark.parametrize("backend", backends)
 def test_image_transpose(backend):
     """
@@ -364,12 +396,12 @@ def test_image_transpose(backend):
     sdf = SarracenDataFrame(df, params=dict())
     sdf.backend = backend
 
-    image1 = interpolate_2d(sdf, 'A', x_pixels=50,  y_pixels=50)
-    image2 = interpolate_2d(sdf, 'A', x='y', y='x', x_pixels=50,  y_pixels=50)
+    image1 = interpolate_2d(sdf, 'A', x_pixels=20,  y_pixels=20)
+    image2 = interpolate_2d(sdf, 'A', x='y', y='x', x_pixels=20,  y_pixels=20)
     assert_allclose(image1, image2.T)
 
-    image1 = interpolate_2d_vec(sdf, 'A', 'B', x_pixels=50, y_pixels=50)
-    image2 = interpolate_2d_vec(sdf, 'A', 'B', x='y', y='x', x_pixels=50, y_pixels=50)
+    image1 = interpolate_2d_vec(sdf, 'A', 'B', x_pixels=20, y_pixels=20)
+    image2 = interpolate_2d_vec(sdf, 'A', 'B', x='y', y='x', x_pixels=20, y_pixels=20)
     assert_allclose(image1[0], image2[0].T)
     assert_allclose(image1[1], image2[1].T)
 
@@ -377,23 +409,27 @@ def test_image_transpose(backend):
                        'h': [1.1, 1.3], 'rho': [0.55, 0.45], 'm': [0.04, 0.05]})
     sdf = SarracenDataFrame(df, params=dict())
 
-    image1 = interpolate_3d(sdf, 'A', x_pixels=50,  y_pixels=50)
-    image2 = interpolate_3d(sdf, 'A', x='y', y='x', x_pixels=50,  y_pixels=50)
+    image1 = interpolate_3d(sdf, 'A', x_pixels=20,  y_pixels=20)
+    image2 = interpolate_3d(sdf, 'A', x='y', y='x', x_pixels=20,  y_pixels=20)
     assert_allclose(image1, image2.T)
 
-    image1 = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=50, y_pixels=50)
-    image2 = interpolate_3d_vec(sdf, 'A', 'B', 'C', x='y', y='x', x_pixels=50, y_pixels=50, y_max=1)
+    image1 = interpolate_3d_vec(sdf, 'A', 'B', 'C', x_pixels=20, y_pixels=20)
+    image2 = interpolate_3d_vec(sdf, 'A', 'B', 'C', x='y', y='x', x_pixels=20, y_pixels=20, y_max=1)
     assert_allclose(image1[0], image2[0].T)
     assert_allclose(image1[1], image2[1].T)
 
-    image1 = interpolate_3d_cross(sdf, 'A', x_pixels=50,  y_pixels=50)
-    image2 = interpolate_3d_cross(sdf, 'A', x='y', y='x', x_pixels=50,  y_pixels=50)
+    image1 = interpolate_3d_cross(sdf, 'A', x_pixels=20,  y_pixels=20)
+    image2 = interpolate_3d_cross(sdf, 'A', x='y', y='x', x_pixels=20,  y_pixels=20)
     assert_allclose(image1, image2.T)
 
-    image1 = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', x_pixels=50, y_pixels=50)
-    image2 = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', x='y', y='x', x_pixels=50, y_pixels=50)
+    image1 = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', x_pixels=20, y_pixels=20)
+    image2 = interpolate_3d_cross_vec(sdf, 'A', 'B', 'C', x='y', y='x', x_pixels=20, y_pixels=20)
     assert_allclose(image1[0], image2[0].T)
     assert_allclose(image1[1], image2[1].T)
+
+    image1 = interpolate_3d_grid(sdf, 'A', x_pixels=20, y_pixels=20)
+    image2 = interpolate_3d_grid(sdf, 'A', x='y', y='x', x_pixels=20, y_pixels=20)
+    assert_allclose(image1, image2.transpose(0, 2, 1))
 
 
 @mark.parametrize("backend", backends)
@@ -437,6 +473,10 @@ def test_default_kernel(backend):
     assert image[0] == kernel.w(0, 3)
     assert image[1] == kernel.w(0, 3)
 
+    image = interpolate_3d_grid(sdf_3, 'A', x_pixels=1, y_pixels=1, z_pixels=1, xlim=(-1, 1), ylim=(-1, 1),
+                                zlim=(-1, 1))
+    assert image == kernel.w(0, 3)
+
     # Next, test that the kernel supplied to the function is actually used.
     kernel = QuinticSplineKernel()
     image = interpolate_2d(sdf_2, 'A', x_pixels=1, y_pixels=1, x_min=-1, x_max=1, y_min=-1, y_max=1, kernel=kernel)
@@ -464,6 +504,10 @@ def test_default_kernel(backend):
     assert image[0] == kernel.w(0, 3)
     assert image[1] == kernel.w(0, 3)
 
+    image = interpolate_3d_grid(sdf_3, 'A', x_pixels=1, y_pixels=1, z_pixels=1, xlim=(-1, 1), ylim=(-1, 1),
+                                zlim=(-1, 1), kernel=kernel)
+    assert image == kernel.w(0, 3)
+
 
 @mark.parametrize("backend", backends)
 def test_column_samples(backend):
@@ -482,20 +526,43 @@ def test_column_samples(backend):
     assert image == kernel.get_column_kernel(2)[0]
 
 
-@mark.parametrize("backend", backends)
-def test_pixel_arguments(backend):
+#@mark.parametrize("backend", backends)
+def test_pixel_arguments():
     """
     Default interpolation pixel counts should be selected to preserve the aspect ratio of the data.
     """
-    df_2 = pd.DataFrame({'x': [-2, 4], 'y': [3, 8], 'A': [1, 1], 'B': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
+    backend = 'cpu'
+
+    df_2 = pd.DataFrame({'x': [-2, 4], 'y': [3, 7], 'A': [1, 1], 'B': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf_2 = SarracenDataFrame(df_2, params=dict())
     sdf_2.backend = backend
-    df_3 = pd.DataFrame({'x': [-2, 4], 'y': [3, 8], 'z': [7, -2], 'A': [1, 1], 'B': [1, 1], 'C': [1, 1], 'h': [1, 1],
+    df_3 = pd.DataFrame({'x': [-2, 4], 'y': [3, 7], 'z': [6, -2], 'A': [1, 1], 'B': [1, 1], 'C': [1, 1], 'h': [1, 1],
                          'rho': [1, 1], 'm': [1, 1]})
     sdf_3 = SarracenDataFrame(df_3, params=dict())
     sdf_3.backend = backend
 
-    default_pixels = 100
+    default_pixels = 12
+
+    # 3D grid interpolation
+    for axes in [('x', 'y', 'z'), ('x', 'z', 'y'), ('y', 'z', 'x'), ('y', 'x', 'z'), ('z', 'x', 'y'), ('z', 'y', 'x')]:
+        ratio01 = np.abs(df_3[axes[0]][1] - df_3[axes[0]][0]) / np.abs(df_3[axes[1]][1] - df_3[axes[1]][0])
+        ratio02 = np.abs(df_3[axes[0]][1] - df_3[axes[0]][0]) / np.abs(df_3[axes[2]][1] - df_3[axes[2]][0])
+        ratio12 = np.abs(df_3[axes[1]][1] - df_3[axes[1]][0]) / np.abs(df_3[axes[2]][1] - df_3[axes[2]][0])
+
+        image = interpolate_3d_grid(sdf_3, 'A', x=axes[0], y=axes[1], z=axes[2])
+        assert image.shape[2] / image.shape[1] == approx(ratio01, rel=1e-2)
+        assert image.shape[1] / image.shape[0] == approx(ratio12, rel=1e-2)
+        assert image.shape[2] / image.shape[0] == approx(ratio02, rel=1e-2)
+
+        image = interpolate_3d_grid(sdf_3, 'A', x=axes[0], y=axes[1], z=axes[2], x_pixels=default_pixels)
+        assert image.shape == (round(default_pixels / ratio02), round(default_pixels / ratio01), default_pixels)
+
+        image = interpolate_3d_grid(sdf_3, 'A', x=axes[0], y=axes[1], z=axes[2], y_pixels=default_pixels)
+        assert image.shape == (round(default_pixels / ratio12), default_pixels, round(default_pixels * ratio01))
+
+        image = interpolate_3d_grid(sdf_3, 'A', x=axes[0], y=axes[1], z=axes[2], x_pixels=default_pixels,
+                                    y_pixels=default_pixels, z_pixels=default_pixels)
+        assert image.shape == (default_pixels, default_pixels, default_pixels)
 
     # Non-vector functions
     for func in [interpolate_2d, interpolate_3d, interpolate_3d_cross]:
@@ -638,6 +705,17 @@ def test_irregular_bounds(backend):
             assert image_vec[1][y][x] == approx(
                 w[0] * sdf['B'][0] * kernel.w(np.sqrt(real_x[x] ** 2 + real_y[y] ** 2 + 0.5 ** 2) / sdf['h'][0], 3))
 
+    real_z = -kernel.get_radius() + 0.5 + (np.arange(0, 15) + 0.5) * (2 * kernel.get_radius() / 15)
+    limit = -kernel.get_radius(), kernel.get_radius()
+
+    image = interpolate_3d_grid(sdf, 'A', x_pixels=50, y_pixels=25, z_pixels=15, xlim=limit, ylim=limit, zlim=limit)
+
+    for z in range(15):
+        for y in range(25):
+            for x in range(50):
+                assert image[z][y][x] == approx(
+                    w[0] * sdf['A'][0] * kernel.w(np.sqrt(real_x[x] ** 2 + real_y[y] ** 2 + real_z[z] ** 2) / sdf['h'][0], 3))
+
 
 @mark.parametrize("backend", backends)
 def test_oob_particles(backend):
@@ -651,7 +729,7 @@ def test_oob_particles(backend):
     sdf_2.kernel = kernel
     sdf_2.backend = backend
 
-    df_3 = pd.DataFrame({'x': [0], 'y': [0], 'z': [-0.5], 'A': [4], 'B': [3], 'C': [2], 'h': [1.9], 'rho': [0.4],
+    df_3 = pd.DataFrame({'x': [0], 'y': [0], 'z': [0.5], 'A': [4], 'B': [3], 'C': [2], 'h': [1.9], 'rho': [0.4],
                          'm': [0.03]})
     sdf_3 = SarracenDataFrame(df_3, params=dict())
     sdf_3.kernel = kernel
@@ -705,6 +783,17 @@ def test_oob_particles(backend):
                 w[0] * sdf_3['A'][0] * kernel.w(np.sqrt(real_x[x] ** 2 + real_y[y] ** 2 + 0.5 ** 2) / sdf_3['h'][0], 3))
             assert image_vec[1][y][x] == approx(
                 w[0] * sdf_3['B'][0] * kernel.w(np.sqrt(real_x[x] ** 2 + real_y[y] ** 2 + 0.5 ** 2) / sdf_3['h'][0], 3))
+
+    real_z = 0.5 + (np.arange(0, 25) + 0.5) * (1 / 25)
+
+    image = interpolate_3d_grid(sdf_3, 'A', x_pixels=25, y_pixels=25, z_pixels=25, xlim=(1, 2), ylim=(1, 2),
+                                zlim=(1, 2))
+
+    for z in range(25):
+        for y in range(25):
+            for x in range(25):
+                image[z][y][x] == approx(w[0] * sdf_3['A'][0] * kernel.w(np.sqrt(real_x[x] ** 2 + real_y[y] ** 2 +
+                                                                                 real_z[z] ** 2), 3))
 
 
 def rotate(target, rot_z, rot_y, rot_x):
@@ -785,6 +874,17 @@ def test_nonstandard_rotation(backend):
             assert image_crossvec[1][y][x] == approx(w_cross[0] * target_y * kernel.w(
                 np.sqrt((pos_x - real[x]) ** 2 + (pos_y - real[y]) ** 2 + pos_z ** 2) / sdf['h'][0], 3))
 
+    image_grid = interpolate_3d_grid(sdf, 'A', x_pixels=50, y_pixels=50, z_pixels=50, xlim=(-1, 1), ylim=(-1, 1),
+                                     zlim=(-1, 1), rotation=[rot_z, rot_y, rot_x], rot_origin=[0, 0, 0])
+
+    for z in range(50):
+        for y in range(50):
+            for x in range(50):
+                assert image_grid[z][y][x] == \
+                       approx(w_cross[0] * sdf['A'][0] * kernel.w(np.sqrt((pos_x - real[x]) ** 2
+                                                                          + (pos_y - real[y]) ** 2
+                                                                          + (pos_z - real[z]) ** 2) / sdf['h'][0], 3))
+
 
 @mark.parametrize("backend", backends)
 def test_scipy_rotation_equivalency(backend):
@@ -829,6 +929,13 @@ def test_scipy_rotation_equivalency(backend):
                                       origin=[0, 0, 0])
     assert_allclose(image1[0], image2[0])
     assert_allclose(image1[1], image2[1])
+
+    image1 = interpolate_3d_grid(sdf, 'A', x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1), zlim=(-1, 1),
+                                 rotation=[rot_z, rot_y, rot_x], rot_origin=[0, 0, 0])
+    image2 = interpolate_3d_grid(sdf, 'A', x_pixels=50, y_pixels=50, xlim=(-1, 1), ylim=(-1, 1), zlim=(-1, 1),
+                                 rotation=Rotation.from_euler('zyx', [rot_z, rot_y, rot_x], degrees=True),
+                                 rot_origin=[0, 0, 0])
+    assert_allclose(image1, image2)
 
 
 @mark.parametrize("backend", backends)
@@ -879,6 +986,16 @@ def test_quaternion_rotation(backend):
                 np.sqrt((pos[0] - real[x]) ** 2 + (pos[1] - real[y]) ** 2 + pos[2] ** 2) / sdf['h'][0], 3))
             assert image_crossvec[1][y][x] == approx(w_cross[0] * val[1] * kernel.w(
                 np.sqrt((pos[0] - real[x]) ** 2 + (pos[1] - real[y]) ** 2 + pos[2] ** 2) / sdf['h'][0], 3))
+
+    image_grid = interpolate_3d_grid(sdf, 'A', x_pixels=50, y_pixels=50, z_pixels=50, xlim=(-1, 1), ylim=(-1, 1),
+                                     zlim=(-1, 1), rotation=quat, rot_origin=[0, 0, 0])
+
+    for z in range(50):
+        for y in range(50):
+            for x in range(50):
+                assert image_grid[z][y][x] == approx(w_cross[0] * sdf['A'][0] * kernel.w(
+                    np.sqrt((pos[0] - real[x]) ** 2 + (pos[1] - real[y]) ** 2 + (pos[2] - real[z]) ** 2)
+                    / sdf['h'][0], 3))
 
 
 @mark.parametrize("backend", backends)
@@ -942,6 +1059,12 @@ def test_axes_rotation_separation(backend):
     assert_allclose(image1[0], image2[0].T)
     assert_allclose(image1[1], image2[1].T)
 
+    image1 = interpolate_3d_grid(sdf, 'A', x_pixels=50, y_pixels=50, z_pixels=50, xlim=(-1, 1), ylim=(-1, 1),
+                                 zlim=(-1, 1), rotation=[234, 90, 48])
+    image2 = interpolate_3d_grid(sdf, 'A', x='y', y='x', x_pixels=50, y_pixels=50, z_pixels=50, xlim=(-1, 1),
+                                 ylim=(-1, 1), zlim=(-1, 1), rotation=[234, 90, 48])
+    assert_allclose(image1, image2.transpose(0, 2, 1))
+
 
 @mark.parametrize("backend", backends)
 def test_axes_rotation_equivalency(backend):
@@ -963,9 +1086,9 @@ def test_axes_rotation_equivalency(backend):
                 rot_x, rot_y, rot_z = i_x * 90, i_y * 90, i_z * 90
 
                 for func in [interpolate_3d, interpolate_3d_cross]:
-                    image1 = func(sdf, 'A', x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1, y_max=1,
+                    image1 = func(sdf, 'A', x_pixels=20, y_pixels=20, x_min=-1, x_max=1, y_min=-1, y_max=1,
                                             rotation=[rot_z, rot_y, rot_x], origin=[0, 0, 0])
-                    image2 = func(sdf, 'A', x=x, y=y, x_pixels=50, y_pixels=50, x_min=-1, x_max=1, y_min=-1,
+                    image2 = func(sdf, 'A', x=x, y=y, x_pixels=20, y_pixels=20, x_min=-1, x_max=1, y_min=-1,
                                             y_max=1)
                     image2 = image2 if not flip_x else np.flip(image2, 1)
                     image2 = image2 if not flip_y else np.flip(image2, 0)
@@ -1014,6 +1137,9 @@ def test_invalid_region(backend):
         with raises(ValueError):
             interpolate_3d_cross_vec(sdf_3, 'A', 'B', 'C', 0, x_min=b[0], x_max=b[1], y_min=b[2], y_max=b[3],
                                      x_pixels=b[4], y_pixels=b[5])
+        with raises(ValueError):
+            interpolate_3d_grid(sdf_3, 'A', xlim=(b[0], b[1]), ylim=(b[2], b[3]), zlim=(-3, 3), x_pixels=b[4],
+                                y_pixels=b[5], z_pixels=10)
 
 
 @mark.parametrize("backend", backends)
@@ -1051,6 +1177,8 @@ def test_required_columns(backend):
             interpolate_3d_vec(sdf_dropped, 'A', 'B', 'C')
         with raises(KeyError):
             interpolate_3d_cross_vec(sdf_dropped, 'A', 'B', 'C')
+        with raises(KeyError):
+            interpolate_3d_grid(sdf_dropped, 'A')
 
 
 @mark.parametrize("backend", backends)


### PR DESCRIPTION
Creates a new interpolation function`interpolate_3d_grid`, which takes a 3D `SarracenDataFrame` and returns an interpolated 3D grid with the specified number of 3D pixels. This function does not have a corresponding rendering function, unlike every other interpolation function prior to this point.

As well, an `sdf.sph_interpolate()` method has been included, which interpolates data within a `SarracenDataFrame` to either a 2D or 3D grid, depending on the number of dimensions within the data. The method is named `sph_interpolate` and not just `interpolate` to avoid conflict the existing `DataFrame.interpolate()` method within pandas.