### PR TITLE
3-Dimensional Line Interpolation

### DIFF
--- a/sarracen/interpolate/__init__.py
+++ b/sarracen/interpolate/__init__.py
@@ -2,4 +2,4 @@ from sarracen.interpolate.base_backend import BaseBackend
 from sarracen.interpolate.cpu_backend import CPUBackend
 from sarracen.interpolate.gpu_backend import GPUBackend
 from sarracen.interpolate.interpolate import interpolate_2d_cross, interpolate_2d, interpolate_3d,\
-    interpolate_3d_cross, interpolate_3d_vec, interpolate_3d_cross_vec, interpolate_2d_vec
+    interpolate_3d_cross, interpolate_3d_vec, interpolate_3d_cross_vec, interpolate_2d_vec, interpolate_3d_line

--- a/sarracen/interpolate/base_backend.py
+++ b/sarracen/interpolate/base_backend.py
@@ -29,6 +29,13 @@ class BaseBackend:
         return zeros(pixels)
 
     @staticmethod
+    def interpolate_3d_line(x: ndarray, y: ndarray, z: ndarray, weight: ndarray, h: ndarray,
+                            weight_function: CPUDispatcher, kernel_radius: float, pixels: int, x1: float, x2: float,
+                            y1: float, y2: float, z1: float, z2: float) -> ndarray:
+        """ Interpolate 3D particle data to a 1D cross-sectional line. """
+        return zeros(pixels)
+
+    @staticmethod
     def interpolate_3d_projection(x: ndarray, y: ndarray, z: ndarray, weight: ndarray, h: ndarray,
                                   weight_function: CPUDispatcher, kernel_radius: float, x_pixels: int, y_pixels: int,
                                   x_min: float, x_max: float, y_min: float, y_max: float, exact: bool) -> ndarray:

--- a/sarracen/interpolate/cpu_backend.py
+++ b/sarracen/interpolate/cpu_backend.py
@@ -94,7 +94,7 @@ class CPUBackend(BaseBackend):
 
         for z_i in np.arange(z_pixels):
             z_val = z_min + (z_i + 0.5) * pixwidthz
-            image[z_i] = CPUBackend._fast_2d(z_val, x, y, z, weight, h, weight_function, kernel_radius, x_pixels,
+            image[z_i] = CPUBackend._fast_2d(x, y, z, z_val, weight, h, weight_function, kernel_radius, x_pixels,
                                              y_pixels, x_min, x_max, y_min, y_max, 3)
 
         return image

--- a/sarracen/interpolate/gpu_backend.py
+++ b/sarracen/interpolate/gpu_backend.py
@@ -96,7 +96,7 @@ class GPUBackend(BaseBackend):
         # todo: this should be separated from _fast_2d to reduce the unnecessary transfer of data to the graphics card.
         for z_i in np.arange(z_pixels):
             z_val = z_min + (z_i + 0.5) * pixwidthz
-            image[z_i] = GPUBackend._fast_2d(z_val, x, y, z, weight, h, weight_function, kernel_radius, x_pixels,
+            image[z_i] = GPUBackend._fast_2d(x, y, z, z_val, weight, h, weight_function, kernel_radius, x_pixels,
                                              y_pixels, x_min, x_max, y_min, y_max, 3)
 
         return image

--- a/sarracen/interpolate/gpu_backend.py
+++ b/sarracen/interpolate/gpu_backend.py
@@ -40,6 +40,13 @@ class GPUBackend(BaseBackend):
         return GPUBackend._fast_2d_cross(x, y, weight, h, weight_function, kernel_radius, pixels, x1, x2, y1, y2)
 
     @staticmethod
+    def interpolate_3d_line(x: ndarray, y: ndarray, z: ndarray, weight: ndarray, h: ndarray,
+                            weight_function: CPUDispatcher, kernel_radius: float, pixels: int, x1: float, x2: float,
+                            y1: float, y2: float, z1: float, z2: float) -> ndarray:
+        return GPUBackend._fast_3d_line(x, y, z, weight, h, weight_function, kernel_radius, pixels, x1, x2, y1, y2, z1,
+                                        z2)
+
+    @staticmethod
     def interpolate_3d_projection(x: ndarray, y: ndarray, z: ndarray, weight: ndarray, h: ndarray,
                                   weight_function: CPUDispatcher, kernel_radius: float, x_pixels: int, y_pixels: int,
                                   x_min: float, x_max: float, y_min: float, y_max: float, exact: bool) -> ndarray:
@@ -363,6 +370,69 @@ class GPUBackend(BaseBackend):
 
         # execute the newly compiled GPU kernel
         _2d_func[blockspergrid, threadsperblock](d_x, d_y, d_w, d_h, kernel_radius, pixels, x1, x2, y1, y2, d_image)
+
+        return d_image.copy_to_host()
+
+    @staticmethod
+    def _fast_3d_line(x_data, y_data, z_data, w_data, h_data, weight_function, kernel_radius, pixels, x1, x2, y1, y2,
+                      z1, z2):
+        dx = x2 - x1
+        dy = y2 - y1
+        dz = z2 - z1
+
+        length = np.sqrt(dx ** 2 + dy ** 2 + dz ** 2)
+        ux, uy, uz = dx / length, dy / length, dz / length
+
+        @cuda.jit(fastmath=True)
+        def _2d_func(x_data, y_data, z_data, w_data, h_data, kernel_radius, pixels, x1, x2, y1, y2, z1, z2, image):
+            i = cuda.grid(1)
+
+            if i < x_data.size:
+                delta = (ux * (x1 - x_data[i]) + uy * (y1 - y_data[i]) + uz * (z1 - z_data[i])) ** 2 \
+                        - ((x1 - x_data[i]) ** 2 + (y1 - y_data[i]) ** 2 + (z1 - z_data[i]) ** 2)\
+                        + (kernel_radius * h_data[i]) ** 2
+                if delta < 0:
+                    return
+
+                term = w_data[i] / h_data[i] ** 3
+
+                d1 = -(ux * (x1 - x_data[i]) + uy * (y1 - y_data[i]) + uz * (z1 - z_data[i])) - math.sqrt(delta)
+                d2 = -(ux * (x1 - x_data[i]) + uy * (y1 - y_data[i]) + uz * (z1 - z_data[i])) + math.sqrt(delta)
+
+                pixmin = min(max(0, round((d1 / length) * pixels)), pixels)
+                pixmax = min(max(0, round((d2 / length) * pixels)), pixels)
+
+                for ipix in range(pixmin, pixmax):
+                    xpix = x1 + (ipix + 0.5) * (x2 - x1) / pixels
+                    ypix = y1 + (ipix + 0.5) * (y2 - y1) / pixels
+                    zpix = z1 + (ipix + 0.5) * (z2 - z1) / pixels
+
+                    xdiff = xpix - x_data[i]
+                    ydiff = ypix - y_data[i]
+                    zdiff = zpix - z_data[i]
+
+                    q2 = (xdiff ** 2 + ydiff ** 2 + zdiff ** 2) * (1 / (h_data[i] ** 2))
+                    wab = weight_function(math.sqrt(q2), 3)
+
+                    cuda.atomic.add(image, ipix, wab * term)
+
+        threadsperblock = 32
+        blockspergrid = (x_data.size + (threadsperblock - 1)) // threadsperblock
+
+        # transfer relevant data to the GPU
+        d_x = cuda.to_device(x_data)
+        d_y = cuda.to_device(y_data)
+        d_z = cuda.to_device(z_data)
+        d_w = cuda.to_device(w_data)
+        d_h = cuda.to_device(h_data)
+
+        # CUDA kernels have no return values, so the image data must be
+        # allocated on the device beforehand.
+        d_image = cuda.to_device(np.zeros(pixels))
+
+        # execute the newly compiled GPU kernel
+        _2d_func[blockspergrid, threadsperblock](d_x, d_y, d_z, d_w, d_h, kernel_radius, pixels, x1, x2, y1, y2, z1, z2,
+                                                 d_image)
 
         return d_image.copy_to_host()
 

--- a/sarracen/interpolate/interpolate.py
+++ b/sarracen/interpolate/interpolate.py
@@ -494,9 +494,47 @@ def interpolate_2d_cross(data: 'SarracenDataFrame', target: str, x: str = None, 
 
 
 def interpolate_3d_line(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None, z: str = None,
-                        kernel: BaseKernel = None, rotation: np.ndarray = None, rot_origin: np.ndarray = None,
-                        pixels: int = None, xlim: tuple[float, float] = None, ylim: tuple[float, float] = None,
-                        zlim: tuple[float, float] = None, backend: str = None):
+                        kernel: BaseKernel = None, pixels: int = None, xlim: tuple[float, float] = None,
+                        ylim: tuple[float, float] = None, zlim: tuple[float, float] = None, backend: str = None):
+    """ Interpolate vector particle data across three directional axes to a 1D line.
+
+    Interpolate the data within a SarracenDataFrame to a 1D line, by interpolating the values
+    of a target variable. The contributions of all particles near the interpolation line are
+    summed and stored to a 1D array.
+
+    Parameters
+    ----------
+    data : SarracenDataFrame
+            Particle data, in a SarracenDataFrame.
+    target: str
+        Column label of the target variable.
+    x, y, z: str
+        Column labels of the directional axes. Defaults to the x, y & z columns detected in `data`.
+    kernel: BaseKernel, optional
+        Kernel to use for smoothing the target data. Defaults to the kernel specified in `data`.
+    pixels: int, optional
+        Number of pixels in the output image in the x & y directions. Default values are chosen to keep
+        a consistent aspect ratio.
+    xlim, ylim, zlim: tuple of float, optional
+        Starting and ending coordinates of the cross-section line (in particle data space). Defaults to
+        the minimum and maximum values of `x`, `y`, and `z`.
+    backend: ['cpu', 'gpu']
+        The computation backend to use when interpolating this data. Defaults to the backend specified in `data`.
+
+    Returns
+    -------
+    output: ndarray (1-Dimensional)
+        The interpolated output line.
+
+    Raises
+    -------
+    ValueError
+        If `pixels` are less than or equal to zero, or
+        if the specified `x`, `y`, and `z` minimum and maximum values result in a zero area cross-section, or
+        if `data` is not 3-dimensional.
+    KeyError
+        If `target`, `x`, `y`, mass, density, or smoothing length data does not exist in `data`.
+    """
     _check_dimension(data, 3)
     x, y = _default_xy(data, x, y)
 

--- a/sarracen/readers/read_phantom.py
+++ b/sarracen/readers/read_phantom.py
@@ -228,4 +228,4 @@ def read_phantom(filename: str, separate_types: str = 'sinks'):
             return [SarracenDataFrame(df, params={**header_vars, **{"mass": header_vars['massoftype']}}),
                     SarracenDataFrame(df_sinks, params=header_vars)]
 
-        return SarracenDataFrame(pd.concat([df, df_sinks], ignore_index=True), params=header_vars)
+        return SarracenDataFrame(pd.concat([df, df_sinks], ignore_index=True), params={**header_vars, **{"mass": header_vars['massoftype']}})

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -228,7 +228,7 @@ def render(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None,
 
 
 def lineplot(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None, z: str = None,
-             kernel: BaseKernel = None, pixels: int = None, xlim: tuple[float, float] = None,
+             kernel: BaseKernel = None, pixels: int = 512, xlim: tuple[float, float] = None,
              ylim: tuple[float, float] = None, zlim: tuple[float, float] = None, ax: Axes = None, backend: str = None,
              log_scale: bool = False, **kwargs):
     """ Render a scalar SPH target variable to line plot.
@@ -294,6 +294,7 @@ def lineplot(data: 'SarracenDataFrame', target: str, x: str = None, y: str = Non
             z2 = _snap(data.loc[:, z].max())
         else:
             z2 = zlim[1]
+        zlim = z2, z1
 
         upper_lim = np.sqrt((xlim[1] - xlim[0]) ** 2 + (ylim[1] - ylim[0]) ** 2 + (zlim[1] - zlim[0]) ** 2)
 
@@ -304,7 +305,7 @@ def lineplot(data: 'SarracenDataFrame', target: str, x: str = None, y: str = Non
 
     ax.margins(x=0, y=0)
 
-    ax.set_xlabel('cross-section' + (f'({x}, {y})' if data.get_dim() == 2 else f'({x}, {y}, {z})'))
+    ax.set_xlabel('cross-section ' + (f'({x}, {y})' if data.get_dim() == 2 else f'({x}, {y}, {z})'))
 
     label = target
     if log_scale:

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -521,11 +521,10 @@ def render_2d_cross(data: 'SarracenDataFrame', target: str, x: str = None, y: st
 
 
 def render_3d_line(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None, z: str = None,
-                   kernel: BaseKernel = None, rotation: np.ndarray = None, rot_origin: np.ndarray = None,
-                   pixels: int = 512, xlim: tuple[float, float] = None, ylim: tuple[float, float] = None,
-                   zlim: tuple[float, float] = None, ax: Axes = None, backend: str = None, log_scale: bool = False,
-                   **kwargs) -> Axes:
-    output = interpolate_3d_line(data, target, x, y, z, kernel, rotation, rot_origin, pixels, xlim, ylim, zlim, backend)
+                   kernel: BaseKernel = None, pixels: int = 512, xlim: tuple[float, float] = None,
+                   ylim: tuple[float, float] = None, zlim: tuple[float, float] = None, ax: Axes = None,
+                   backend: str = None, log_scale: bool = False, **kwargs) -> Axes:
+    output = interpolate_3d_line(data, target, x, y, z, kernel, pixels, xlim, ylim, zlim, backend)
 
     if ax is None:
         ax = plt.gca()

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -5,7 +5,8 @@ from matplotlib.colors import Colormap
 from pandas import DataFrame, Series
 import numpy as np
 
-from sarracen.render import render_2d, render_2d_cross, render_3d, render_3d_cross, streamlines, arrowplot
+from sarracen.render import render_2d, render_2d_cross, render_3d, render_3d_cross, streamlines, arrowplot, \
+    render_3d_line
 from sarracen.kernels import CubicSplineKernel, BaseKernel
 
 
@@ -187,6 +188,13 @@ class SarracenDataFrame(DataFrame):
 
         return render_3d_cross(self, target, z_slice, x, y, z, kernel, rotation, rot_origin, x_pixels, y_pixels, x_min,
                                x_max, y_min, y_max, cmap, cbar, cbar_kws, cbar_ax, ax, backend, log_scale, **kwargs)
+
+    @_copy_doc(render_3d_line)
+    def render_3d_line(self, target: str, x: str = None, y: str = None, z: str = None, kernel: BaseKernel = None,
+                       pixels: int = 512, xlim: tuple[float, float] = None, ylim: tuple[float, float] = None,
+                       zlim: tuple[float, float] = None, ax: Axes = None, backend: str = None, log_scale: bool = False,
+                       **kwargs) -> Axes:
+        return render_3d_line(self, target, x, y, z, kernel, pixels, xlim, ylim, zlim, ax, backend, log_scale, **kwargs)
 
     @_copy_doc(streamlines)
     def streamlines(self, target: Union[Tuple[str, str], Tuple[str, str, str]], z_slice: int = None, x: str = None,

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -162,7 +162,7 @@ class SarracenDataFrame(DataFrame):
 
     @_copy_doc(lineplot)
     def lineplot(self, target: str, x: str = None, y: str = None, z: str = None,
-                 kernel: BaseKernel = None, pixels: int = None, xlim: tuple[float, float] = None,
+                 kernel: BaseKernel = None, pixels: int = 512, xlim: tuple[float, float] = None,
                  ylim: tuple[float, float] = None, zlim: tuple[float, float] = None, ax: Axes = None,
                  backend: str = None, log_scale: bool = False, **kwargs):
         return lineplot(self, target, x, y, z, kernel, pixels, xlim, ylim, zlim, ax, backend, log_scale, **kwargs)


### PR DESCRIPTION
Adds a new interpolation / rendering function `render_3d_line`, which takes an SPH cross-sectional line defined by two coordinates in data space. This is very similar to `render_2d_line`, except it is specifically designed to work in 3 dimensions. The two coordinates can be anywhere in 3D space (except they cannot both be in the same place).

Example (3D -> 2D cross section on left, 3D -> 1D line interpolation on right from (-0.5, -0.5) to (0.5, 0.5)):
![image](https://user-images.githubusercontent.com/71343838/183494979-820fa938-799f-48a5-a5a9-a47991d565f7.png)
 