### PR TITLE
Expand installation documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,14 +8,19 @@ Sarracen documentation
 
 Sarracen is a Python library for analysis and visualization of smoothed particle hydrodynamics (SPH) data.
 
-It is built upon the pandas and Matplotlib data and visualization libraries.  SPH data can be loaded into a pandas DataFrame structure that has been extended to support SPH. Visualizations of the data use the SPH kernel, and a variety of rendering options are available. All SPH interpolation functions are optimized using Numba into machine code with both multi-threaded and CUDA enabled routines. Our primary intended application is for astrophysical SPH simulations.
+It is built upon the pandas and Matplotlib data and visualization libraries.  SPH data can be loaded into a pandas
+DataFrame structure that has been extended to support SPH. Visualizations of the data use the SPH kernel, and a variety
+of rendering options are available. All SPH interpolation functions are optimized using Numba into machine code with
+both multi-threaded and CUDA enabled routines. Our primary intended application is for astrophysical SPH simulations.
 
-Visit the :ref:`quick start guide <quick_start>` to learn the basics of Sarracen. For details on specific functions, consult the :ref:`API reference <api>`. The codebase can be found on `Github <https://github.com/ttricco/sarracen/>`_.
+Visit the :ref:`quick start guide <quick_start>` to learn the basics of Sarracen. For details on specific functions,
+consult the :ref:`API reference <api>`. The codebase can be found on `GitHub <https://github.com/ttricco/sarracen/>`_.
 
 .. toctree::
    :maxdepth: 1
    :caption: Contents:
 
+   installation
    quick-start
    render
    examples

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,61 @@
+.. _installation:
+
+============
+Installation
+============
+
+Stable Release (Recommended)
+----------------------------
+
+The latest stable release and associated dependencies can be installed from `PyPi <https://pypi.org/project/sarracen/>`_:
+
+.. code-block::
+
+    pip install sarracen
+
+This is the recommended way to install Sarracen.
+
+Development Snapshot (via pip)
+------------------------------
+
+The latest development snapshot is available on the `GitHub repository <https://github.com/ttricco/sarracen>`_. This can
+be installed directly through pip by using
+
+.. code-block::
+
+    pip install git+https://github.com/ttricco/sarracen.git
+
+This will install Sarracen in your local environment, as well as any required dependencies.
+
+Development Snapshot (via git)
+------------------------------
+
+Alternatively, the repository can be cloned locally and the dependencies installed manually. First, clone the
+repository to your local machine either using the https link
+
+.. code-block::
+
+    git clone https://github.com/ttricco/sarracen.git
+
+or clone through ssh using a password-protected ssh key
+
+.. code-block::
+
+    git clone git@github.com:ttricco/sarracen.git
+
+The list of dependencies are stored in requirements.txt. These can be installed into your Python environment using pip
+
+.. code-block::
+
+    pip install -r requirements.txt
+
+This method does not install Sarracen as a package in your Python environment. You will need to define the path to
+Sarracen so that your Python code can locate it. See below.
+
+.. code-block::
+
+    import sys
+    sys.path.append('/path/to/sarracen')  # replace with your path to Sarracen
+
+    import sarracen
+

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -4,23 +4,6 @@
 Quick Start Guide
 =================
 
-Installation
-------------
-
-The latest stable release and associated dependencies can be installed from PyPi:
-
-.. code-block::
-
-    pip install sarracen
-
-This is the recommended way to install Sarracen.
-
-The latest development snapshot is available on the GitHub repository. Either clone the repository and add it to your path so that it can be imported, or install directly through pip:
-
-.. code-block::
-
-    pip install git+https://github.com/ttricco/sarracen.git
-
 
 
 Loading data into a SarracenDataFrame
@@ -32,15 +15,15 @@ Additionally, Sarracen can read the native binary format of `Phantom <https://ph
 
 Loading Phantom data is as straightforward as
 
-.. code-block::
-
-   sdf = sarracen.read_phantom('dumpfile')
+>>> import sarracen
+>>>
+>>> sdf = sarracen.read_phantom('dumpfile')
 
 This call can separate different particle species into their own SarracenDataFrame. By default, sink particles are separated, and a list of SarracenDataFrames is returned in such a case. For example, if you data contains SPH particles plus sink particles, a sensible call would be
 
-.. code-block::
-
-   sdf, sdf_sinks = sarracen.read_phantom('dumpfile')
+>>> import sarracen
+>>>
+>>> sdf, sdf_sinks = sarracen.read_phantom('dumpfile')
 
 If you encounter any bugs with file reading for your particular set up, please contact us or raise an issue.
 
@@ -75,14 +58,10 @@ The pandas DataFrame (and hence SarracenDataFrame) is a swiss army knife of data
 
 The below will compute the magnitude of the velocity and store the result as a new column in the data frame. Note the use of numpy.
 
-.. code-block::
-
-   sdf['vmag'] = np.sqrt(sdf['vx']**2 + sdf['vy']**2 + sdf['vz']**2)
+>>> sdf['vmag'] = np.sqrt(sdf['vx']**2 + sdf['vy']**2 + sdf['vz']**2)
 
 Extracting subsets of data can be done using boolean logic to slice into the data frame. The example below computes the average speed of particles above a certain critical density threshold. The first set of square brackets will return a `copy` of the data frame containing only the particles that have density greater than ``rho_crit``, while the second square brackets accesses the column ``vmag`` of that copy.
 
-.. code-block::
-
-   rho_crit = 1.0e10
-   sdf.calc_density()
-   sdf[sdf['rho'] > rho_crit]['vmag'].mean()
+>>> rho_crit = 1.0e10
+>>> sdf.calc_density()
+>>> sdf[sdf['rho'] > rho_crit]['vmag'].mean()


### PR DESCRIPTION
Expand the documentation to have installation instructions for the latest stable release via PyPi, and the latest development snapshots from GitHub with information on how to manually handle dependencies.