### PR TITLE
Pixel culling fix for exact interpolation

### DIFF
--- a/sarracen/interpolate/cpu_backend.py
+++ b/sarracen/interpolate/cpu_backend.py
@@ -133,10 +133,10 @@ class CPUBackend(BaseBackend):
                     continue
 
                 # determine maximum and minimum pixels that this particle contributes to
-                ipixmin = int(np.rint((x_data[i] - kernel_radius * h_data[i] - x_min) / pixwidthx))
-                jpixmin = int(np.rint((y_data[i] - kernel_radius * h_data[i] - y_min) / pixwidthy))
-                ipixmax = int(np.rint((x_data[i] + kernel_radius * h_data[i] - x_min) / pixwidthx))
-                jpixmax = int(np.rint((y_data[i] + kernel_radius * h_data[i] - y_min) / pixwidthy))
+                ipixmin = int(np.floor((x_data[i] - kernel_radius * h_data[i] - x_min) / pixwidthx))
+                jpixmin = int(np.floor((y_data[i] - kernel_radius * h_data[i] - y_min) / pixwidthy))
+                ipixmax = int(np.ceil((x_data[i] + kernel_radius * h_data[i] - x_min) / pixwidthx))
+                jpixmax = int(np.ceil((y_data[i] + kernel_radius * h_data[i] - y_min) / pixwidthy))
 
                 if ipixmax < 0 or ipixmin > x_pixels or jpixmax < 0 or jpixmin > y_pixels:
                     continue
@@ -194,10 +194,10 @@ class CPUBackend(BaseBackend):
             for i in range(range_start, range_end):
 
                 # determine maximum and minimum pixels that this particle contributes to
-                ipixmin = int(np.rint((x_data[i] - 2 * h_data[i] - x_min) / pixwidthx))
-                jpixmin = int(np.rint((y_data[i] - 2 * h_data[i] - y_min) / pixwidthy))
-                ipixmax = int(np.rint((x_data[i] + 2 * h_data[i] - x_min) / pixwidthx))
-                jpixmax = int(np.rint((y_data[i] + 2 * h_data[i] - y_min) / pixwidthy))
+                ipixmin = int(np.floor((x_data[i] - 2 * h_data[i] - x_min) / pixwidthx))
+                jpixmin = int(np.floor((y_data[i] - 2 * h_data[i] - y_min) / pixwidthy))
+                ipixmax = int(np.ceil((x_data[i] + 2 * h_data[i] - x_min) / pixwidthx))
+                jpixmax = int(np.ceil((y_data[i] + 2 * h_data[i] - y_min) / pixwidthy))
 
                 if ipixmax < 0 or ipixmin >= x_pixels or jpixmax < 0 or jpixmin >= y_pixels:
                     continue
@@ -335,8 +335,8 @@ class CPUBackend(BaseBackend):
         xstart, xend = None, None
 
         # the maximum and minimum pixels that each particle contributes to.
-        ipixmin = np.rint(rstart / pixwidth).clip(a_min=0, a_max=pixels)
-        ipixmax = np.rint(rend / pixwidth).clip(a_min=0, a_max=pixels)
+        ipixmin = np.floor(rstart / pixwidth).clip(a_min=0, a_max=pixels)
+        ipixmax = np.ceil(rend / pixwidth).clip(a_min=0, a_max=pixels)
         rstart, rend = None, None
 
         output_local = np.zeros((get_num_threads(), pixels))
@@ -440,10 +440,10 @@ class CPUBackend(BaseBackend):
             for i in range(range_start, range_end):
 
                 # determine maximum and minimum pixels that this particle contributes to
-                ipixmin = int(np.rint((x_data[i] - 2 * h_data[i] - x_min) / pixwidthx))
-                jpixmin = int(np.rint((y_data[i] - 2 * h_data[i] - y_min) / pixwidthy))
-                ipixmax = int(np.rint((x_data[i] + 2 * h_data[i] - x_min) / pixwidthx))
-                jpixmax = int(np.rint((y_data[i] + 2 * h_data[i] - y_min) / pixwidthy))
+                ipixmin = int(np.floor((x_data[i] - 2 * h_data[i] - x_min) / pixwidthx))
+                jpixmin = int(np.floor((y_data[i] - 2 * h_data[i] - y_min) / pixwidthy))
+                ipixmax = int(np.ceil((x_data[i] + 2 * h_data[i] - x_min) / pixwidthx))
+                jpixmax = int(np.ceil((y_data[i] + 2 * h_data[i] - y_min) / pixwidthy))
 
                 # The width of the z contribution of this particle.
                 # = 2 * kernel_radius * h[i], where kernel_radius is 2 for the cubic spline kernel.

--- a/sarracen/interpolate/cpu_backend.py
+++ b/sarracen/interpolate/cpu_backend.py
@@ -133,10 +133,10 @@ class CPUBackend(BaseBackend):
                     continue
 
                 # determine maximum and minimum pixels that this particle contributes to
-                ipixmin = int(np.floor((x_data[i] - kernel_radius * h_data[i] - x_min) / pixwidthx))
-                jpixmin = int(np.floor((y_data[i] - kernel_radius * h_data[i] - y_min) / pixwidthy))
-                ipixmax = int(np.ceil((x_data[i] + kernel_radius * h_data[i] - x_min) / pixwidthx))
-                jpixmax = int(np.ceil((y_data[i] + kernel_radius * h_data[i] - y_min) / pixwidthy))
+                ipixmin = int(np.rint((x_data[i] - kernel_radius * h_data[i] - x_min) / pixwidthx))
+                jpixmin = int(np.rint((y_data[i] - kernel_radius * h_data[i] - y_min) / pixwidthy))
+                ipixmax = int(np.rint((x_data[i] + kernel_radius * h_data[i] - x_min) / pixwidthx))
+                jpixmax = int(np.rint((y_data[i] + kernel_radius * h_data[i] - y_min) / pixwidthy))
 
                 if ipixmax < 0 or ipixmin > x_pixels or jpixmax < 0 or jpixmin > y_pixels:
                     continue
@@ -335,8 +335,8 @@ class CPUBackend(BaseBackend):
         xstart, xend = None, None
 
         # the maximum and minimum pixels that each particle contributes to.
-        ipixmin = np.floor(rstart / pixwidth).clip(a_min=0, a_max=pixels)
-        ipixmax = np.ceil(rend / pixwidth).clip(a_min=0, a_max=pixels)
+        ipixmin = np.rint(rstart / pixwidth).clip(a_min=0, a_max=pixels)
+        ipixmax = np.rint(rend / pixwidth).clip(a_min=0, a_max=pixels)
         rstart, rend = None, None
 
         output_local = np.zeros((get_num_threads(), pixels))

--- a/sarracen/interpolate/gpu_backend.py
+++ b/sarracen/interpolate/gpu_backend.py
@@ -127,10 +127,10 @@ class GPUBackend(BaseBackend):
                     return
 
                 # determine maximum and minimum pixels that this particle contributes to
-                ipixmin = round((x_data[i] - kernel_radius * h_data[i] - x_min) / pixwidthx)
-                jpixmin = round((y_data[i] - kernel_radius * h_data[i] - y_min) / pixwidthy)
-                ipixmax = round((x_data[i] + kernel_radius * h_data[i] - x_min) / pixwidthx)
-                jpixmax = round((y_data[i] + kernel_radius * h_data[i] - y_min) / pixwidthy)
+                ipixmin = math.floor((x_data[i] - kernel_radius * h_data[i] - x_min) / pixwidthx)
+                jpixmin = math.floor((y_data[i] - kernel_radius * h_data[i] - y_min) / pixwidthy)
+                ipixmax = math.ceil((x_data[i] + kernel_radius * h_data[i] - x_min) / pixwidthx)
+                jpixmax = math.ceil((y_data[i] + kernel_radius * h_data[i] - y_min) / pixwidthy)
 
                 if ipixmax < 0 or ipixmin > x_pixels or jpixmax < 0 or jpixmin > y_pixels:
                     return
@@ -201,10 +201,10 @@ class GPUBackend(BaseBackend):
                 term = w_data[i] / h_data[i] ** 2
 
                 # determine maximum and minimum pixels that this particle contributes to
-                ipixmin = round((x_data[i] - 2 * h_data[i] - x_min) / pixwidthx)
-                jpixmin = round((y_data[i] - 2 * h_data[i] - y_min) / pixwidthy)
-                ipixmax = round((x_data[i] + 2 * h_data[i] - x_min) / pixwidthx)
-                jpixmax = round((y_data[i] + 2 * h_data[i] - y_min) / pixwidthy)
+                ipixmin = math.floor((x_data[i] - 2 * h_data[i] - x_min) / pixwidthx)
+                jpixmin = math.floor((y_data[i] - 2 * h_data[i] - y_min) / pixwidthy)
+                ipixmax = math.ceil((x_data[i] + 2 * h_data[i] - x_min) / pixwidthx)
+                jpixmax = math.ceil((y_data[i] + 2 * h_data[i] - y_min) / pixwidthy)
 
                 if ipixmax < 0 or ipixmin >= x_pixels or jpixmax < 0 or jpixmin >= y_pixels:
                     return
@@ -354,8 +354,8 @@ class GPUBackend(BaseBackend):
                 rend = math.sqrt((xend - x1) ** 2 + (((gradient * xend + yint) - y1) ** 2))
 
                 # the maximum and minimum pixels that each particle contributes to.
-                ipixmin = min(max(0, round(rstart / pixwidth)), pixels)
-                ipixmax = min(max(0, round(rend / pixwidth)), pixels)
+                ipixmin = min(max(0, math.floor(rstart / pixwidth)), pixels)
+                ipixmax = min(max(0, math.ceil(rend / pixwidth)), pixels)
 
                 # iterate through all affected pixels
                 for ipix in range(ipixmin, ipixmax):
@@ -415,8 +415,8 @@ class GPUBackend(BaseBackend):
                 d1 = -(ux * (x1 - x_data[i]) + uy * (y1 - y_data[i]) + uz * (z1 - z_data[i])) - math.sqrt(delta)
                 d2 = -(ux * (x1 - x_data[i]) + uy * (y1 - y_data[i]) + uz * (z1 - z_data[i])) + math.sqrt(delta)
 
-                pixmin = min(max(0, round((d1 / length) * pixels)), pixels)
-                pixmax = min(max(0, round((d2 / length) * pixels)), pixels)
+                pixmin = min(max(0, math.floor((d1 / length) * pixels)), pixels)
+                pixmax = min(max(0, math.ceil((d2 / length) * pixels)), pixels)
 
                 for ipix in range(pixmin, pixmax):
                     xpix = x1 + (ipix + 0.5) * (x2 - x1) / pixels
@@ -467,10 +467,10 @@ class GPUBackend(BaseBackend):
                 term = norm3d * w_data[i] / h_data[i] ** 3
 
                 # determine maximum and minimum pixels that this particle contributes to
-                ipixmin = round((x_data[i] - 2 * h_data[i] - x_min) / pixwidthx)
-                jpixmin = round((y_data[i] - 2 * h_data[i] - y_min) / pixwidthy)
-                ipixmax = round((x_data[i] + 2 * h_data[i] - x_min) / pixwidthx)
-                jpixmax = round((y_data[i] + 2 * h_data[i] - y_min) / pixwidthy)
+                ipixmin = math.floor((x_data[i] - 2 * h_data[i] - x_min) / pixwidthx)
+                jpixmin = math.floor((y_data[i] - 2 * h_data[i] - y_min) / pixwidthy)
+                ipixmax = math.ceil((x_data[i] + 2 * h_data[i] - x_min) / pixwidthx)
+                jpixmax = math.ceil((y_data[i] + 2 * h_data[i] - y_min) / pixwidthy)
 
                 # The width of the z contribution of this particle.
                 # = 2 * kernel_radius * h[i], where kernel_radius is 2 for the cubic spline kernel.

--- a/sarracen/interpolate/gpu_backend.py
+++ b/sarracen/interpolate/gpu_backend.py
@@ -127,10 +127,10 @@ class GPUBackend(BaseBackend):
                     return
 
                 # determine maximum and minimum pixels that this particle contributes to
-                ipixmin = math.floor((x_data[i] - kernel_radius * h_data[i] - x_min) / pixwidthx)
-                jpixmin = math.floor((y_data[i] - kernel_radius * h_data[i] - y_min) / pixwidthy)
-                ipixmax = math.ceil((x_data[i] + kernel_radius * h_data[i] - x_min) / pixwidthx)
-                jpixmax = math.ceil((y_data[i] + kernel_radius * h_data[i] - y_min) / pixwidthy)
+                ipixmin = round((x_data[i] - kernel_radius * h_data[i] - x_min) / pixwidthx)
+                jpixmin = round((y_data[i] - kernel_radius * h_data[i] - y_min) / pixwidthy)
+                ipixmax = round((x_data[i] + kernel_radius * h_data[i] - x_min) / pixwidthx)
+                jpixmax = round((y_data[i] + kernel_radius * h_data[i] - y_min) / pixwidthy)
 
                 if ipixmax < 0 or ipixmin > x_pixels or jpixmax < 0 or jpixmin > y_pixels:
                     return
@@ -354,8 +354,8 @@ class GPUBackend(BaseBackend):
                 rend = math.sqrt((xend - x1) ** 2 + (((gradient * xend + yint) - y1) ** 2))
 
                 # the maximum and minimum pixels that each particle contributes to.
-                ipixmin = min(max(0, math.floor(rstart / pixwidth)), pixels)
-                ipixmax = min(max(0, math.ceil(rend / pixwidth)), pixels)
+                ipixmin = min(max(0, round(rstart / pixwidth)), pixels)
+                ipixmax = min(max(0, round(rend / pixwidth)), pixels)
 
                 # iterate through all affected pixels
                 for ipix in range(ipixmin, ipixmax):
@@ -415,8 +415,8 @@ class GPUBackend(BaseBackend):
                 d1 = -(ux * (x1 - x_data[i]) + uy * (y1 - y_data[i]) + uz * (z1 - z_data[i])) - math.sqrt(delta)
                 d2 = -(ux * (x1 - x_data[i]) + uy * (y1 - y_data[i]) + uz * (z1 - z_data[i])) + math.sqrt(delta)
 
-                pixmin = min(max(0, math.floor((d1 / length) * pixels)), pixels)
-                pixmax = min(max(0, math.ceil((d2 / length) * pixels)), pixels)
+                pixmin = min(max(0, round((d1 / length) * pixels)), pixels)
+                pixmax = min(max(0, round((d2 / length) * pixels)), pixels)
 
                 for ipix in range(pixmin, pixmax):
                     xpix = x1 + (ipix + 0.5) * (x2 - x1) / pixels

--- a/sarracen/tests/test_interpolate.py
+++ b/sarracen/tests/test_interpolate.py
@@ -1357,51 +1357,16 @@ def test_normalize_interpolation(backend):
         assert image[0] == weight3d * sdf_2['A'][0] / norm3d
 
 
-def _lattice_init_square(nx=32, ny=32):
-    """ Create a lattice of particles in square arrangement. """
-
-    if nx < 1 or ny < 1:
-        raise ValueError("Error creating lattice. nx and ny must be positive.")
-
-    rx = [(i + 0.5) / nx for i in range(nx)]
-    ry = [(i + 0.5) / nx for i in range(ny)]
-
-    return pd.DataFrame({'rx': [x for x in rx for y in ry],
-                         'ry': [y for x in rx for y in ry]})
-
-
 @mark.parametrize("backend", backends)
-def test_exact_interpolation_gradient(backend):
-    """
-    Test that exact interpolation exactly returns the gradient.
-    """
+def test_exact_interpolation_culling(backend):
+    sdf_2 = SarracenDataFrame({'x': [0], 'y': [0], 'A': [2], 'h': [0.4], 'rho': [0.1], 'm': [1]}, params=dict())
+    sdf_2.backend = backend
+    sdf_3 = SarracenDataFrame({'x': [0], 'y': [0], 'z': [0], 'A': [2], 'h': [0.4], 'rho': [0.1], 'm': [1]},
+                              params=dict())
+    sdf_3.backend = backend
 
-    for xpixels in [32, 64, 128, 256]:
-        for ypixels in [16, 24]:
-            for dimensions in [2, 3]:
-                df = _lattice_init_square(xpixels, ypixels)
+    image_2 = sdf_2.sph_interpolate('A', xlim=(-1, 1), ylim=(-1, 1), x_pixels=5, exact=True)
+    image_3 = interpolate_3d_proj(sdf_3, 'A', xlim=(-1, 1), ylim=(-1, 1), x_pixels=5, exact=True)
 
-                # density is set to 1.567 and total mass calculated from this area
-                mass = 1.567 * 1.0 * (ypixels / xpixels) / (xpixels * ypixels)
-
-                df['h'] = 1.2 * np.sqrt(mass / 1.567)
-                df['A'] = 12.347 * df['rx'] + 1.56
-
-                if dimensions == 2:
-                    sdf = SarracenDataFrame(df, params={'hfact': 1.2, 'mass': mass})
-                    sdf.backend = backend
-
-                    interpolation = sdf.sph_interpolate('A', x_pixels=xpixels, y_pixels=ypixels,
-                                                xlim=(0, 1), ylim=(0, ypixels / xpixels), exact=True)
-                else:
-                    df['rz'] = np.zeros_like(df['rx'])
-                    sdf = SarracenDataFrame(df, params={'hfact': 1.2, 'mass': mass})
-                    sdf.backend = backend
-
-                    interpolation = interpolate_3d_proj(sdf, 'A', x_pixels=xpixels, y_pixels=ypixels,
-                                                xlim=(0, 1), ylim=(0, ypixels / xpixels), exact=True)
-
-                for row in interpolation[2:-2, 2:-2]:  # check all rows skipping edge effects
-                    for i, value in zip(range(xpixels-4), row):
-                        expected_value = 12.347 * (i + 2.5) / xpixels + 1.56
-                        assert value - expected_value < 1.0e-13
+    assert image_2[2, 4] != 0
+    assert image_3[2, 4] != 0


### PR DESCRIPTION
Fixes cases for exact rendering where pixels on the edge of a particle's smoothing circle were incorrectly cut.

As an example, here is a single particle drawn at a low resolution for both exact & fast rendering with this change applied:
![image](https://user-images.githubusercontent.com/71343838/231553692-ac16c534-1352-42a9-b378-453af4d660d5.png)

Before this fix, the exact and fast interpolations looked identical, with the outermost pixels not included in the exact interpolation.

This should resolve #49.