### PR TITLE
Allow custom colorbar custom label

### DIFF
--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -290,12 +290,13 @@ def render(data: 'SarracenDataFrame', target: str, x: str = None, y: str = None,
 
     if cbar:
         colorbar = ax.figure.colorbar(graphic, cbar_ax, ax, **cbar_kws)
-        label = target
-        if data.get_dim() == 3 and xsec is None:
-            label = f"column {label}"
-        if log_scale:
-            label = f"log ({label})"
-        colorbar.ax.set_ylabel(label)
+        if 'label' not in cbar_kws :
+            label = target
+            if data.get_dim() == 3 and xsec is None:
+                label = f"column {label}"
+            if log_scale:
+                label = f"log ({label})"
+            colorbar.ax.set_ylabel(label)
 
     return ax
 


### PR DESCRIPTION
Allow custom colorbar custom label when rendering. Label of the colorbar is defined as previously if 'label' is not in the cbar_kws dictionnary.