### PR TITLE
Phantom data reads and multiple particle types

### DIFF
--- a/sarracen/readers/read_phantom.py
+++ b/sarracen/readers/read_phantom.py
@@ -250,12 +250,14 @@ def read_phantom(filename: str, separate_types: str = 'sinks', ignore_inactive: 
                 df_list = [SarracenDataFrame(df, params=header_vars)]
 
             if not df_sinks.empty:
-                df_list.append(SarracenDataFrame(df_sinks, params=header_vars))
+                df_list.append(SarracenDataFrame(df_sinks,
+                                                 params={key: value for key, value in header_vars.items() if key != 'mass'}))
 
         elif separate_types == 'sinks':
             df_list = [SarracenDataFrame(df, params=header_vars)]
             if not df_sinks.empty:
-                df_list.append(SarracenDataFrame(df_sinks, params=header_vars))
+                df_list.append(SarracenDataFrame(df_sinks,
+                                                 params={key: value for key, value in header_vars.items() if key != 'mass'}))
         else:
             df_list = [SarracenDataFrame(pd.concat([df, df_sinks], ignore_index=True),
                                         params=header_vars)]

--- a/sarracen/readers/read_phantom.py
+++ b/sarracen/readers/read_phantom.py
@@ -186,6 +186,17 @@ def _read_array_blocks(fp, def_int_dtype, def_real_dtype):
     return df, df_sinks
 
 
+def _create_mass_column(df, header_vars):
+    """
+    Creates a mass column with the mass of each particle when there are
+    multiple itypes.
+    """
+    df['mass'] = header_vars['massoftype']
+    for itype in df['itype'].unique():
+        if itype > 1:
+            df.loc[df.itype == itype, 'mass'] = header_vars[f'massoftype_{itype}']
+    return df
+
 def read_phantom(filename: str, separate_types: str = 'sinks', ignore_inactive: bool = True):
     """
     Read data from a Phantom dump file.
@@ -240,22 +251,34 @@ def read_phantom(filename: str, separate_types: str = 'sinks', ignore_inactive: 
         if ignore_inactive:
             df = df[df['h'] > 0]
 
-        if separate_types == 'all' and 'itype' in df and df['itype'].nunique() > 1:
-            df_list = []
-            for _, group in df.groupby('itype'):
-                itype = int(group["itype"].iloc[0])
-                mass_key = 'massoftype' if itype == 1 else f'massoftype_{itype}'
-                df_list.append(SarracenDataFrame(group.dropna(axis=1),
-                                                 params={**header_vars, **{"mass": header_vars[mass_key]}}))
+        # create mass column if multiple species in single dataframe
+        if separate_types != 'all' and 'itype' in df and df['itype'].nunique() > 1:
+            df = _create_mass_column(df, header_vars)
+        else:  # create global mass parameter
+            header_vars['mass'] = header_vars['massoftype']
+
+        df_list = []
+        if separate_types == 'all':
+            if 'itype' in df and df['itype'].nunique() > 1:
+                for _, group in df.groupby('itype'):
+                    itype = int(group["itype"].iloc[0])
+                    mass_key = 'massoftype' if itype == 1 else f'massoftype_{itype}'
+                    df_list.append(SarracenDataFrame(group.dropna(axis=1),
+                                                     params={**header_vars, **{"mass": header_vars[mass_key]}}))
+            else:
+                df_list = [SarracenDataFrame(df, params=header_vars)]
 
             if not df_sinks.empty:
                 df_list.append(SarracenDataFrame(df_sinks, params=header_vars))
 
-            return df_list
+        elif separate_types == 'sinks':
+            df_list = [SarracenDataFrame(df, params=header_vars)]
+            if not df_sinks.empty:
+                df_list.append(SarracenDataFrame(df_sinks, params=header_vars))
+        else:
+            df_list = [SarracenDataFrame(pd.concat([df, df_sinks], ignore_index=True),
+                                        params=header_vars)]
 
-        if (separate_types == 'sinks' or separate_types == 'all') and not df_sinks.empty:
-            return [SarracenDataFrame(df, params={**header_vars, **{"mass": header_vars['massoftype']}}),
-                    SarracenDataFrame(df_sinks, params=header_vars)]
+        df_list = df_list[0] if len(df_list) == 1 else df_list
 
-        return SarracenDataFrame(pd.concat([df, df_sinks], ignore_index=True),
-                                 params={**header_vars, **{"mass": header_vars['massoftype']}})
+        return df_list

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -202,10 +202,11 @@ class SarracenDataFrame(DataFrame):
         if not {self.mcol}.issubset(self.columns) and 'mass' not in self.params:
             raise KeyError('Missing particle mass data in this SarracenDataFrame.')
 
-        mass = self.params['mass']
         # prioritize using mass per particle, if present
         if {self.mcol}.issubset(self.columns):
             mass = self[self.mcol]
+        else:
+            mass = self.params['mass']
 
         self['rho'] = (self.params['hfact'] / self[self.hcol]) ** (self.get_dim()) * mass
         self.rhocol = 'rho'

--- a/sarracen/tests/readers/test_read_phantom.py
+++ b/sarracen/tests/readers/test_read_phantom.py
@@ -98,13 +98,8 @@ def test_determine_default_precision(def_int, def_real):
 
 def test_gas_particles_only():
 
-    # capture pattern
     bytes_file = _create_capture_pattern(np.int32, np.float64)
-
-    # file identifier
     bytes_file += _create_file_identifier()
-
-    # global header
     bytes_file += _create_global_header()
 
     # create 1 block for gas
@@ -155,13 +150,8 @@ def test_gas_particles_only():
 
 def test_gas_dust_particles():
 
-    # capture pattern
     bytes_file = _create_capture_pattern(np.int32, np.float64)
-
-    # file identifier
     bytes_file += _create_file_identifier()
-
-    # global header
     bytes_file += _create_global_header(massoftype_7=1e-4)
 
     # create 1 block for gas
@@ -179,8 +169,7 @@ def test_gas_dust_particles():
     bytes_file += bytearray(nums.tobytes())
     bytes_file += bytearray(read_tag.tobytes())
 
-    # write 4 particle arrays
-
+    # write 5 gas/dust particle arrays
     bytes_file += _create_particle_array("itype", [1, 1, 1, 1, 1, 1, 1, 1,
                                          7, 7, 7, 7, 7, 7, 7, 7], np.int8)
     bytes_file += _create_particle_array("x", [0, 0, 0, 0, 1, 1, 1, 1,
@@ -241,13 +230,8 @@ def test_gas_dust_particles():
 
 def test_gas_sink_particles():
 
-    # capture pattern
     bytes_file = _create_capture_pattern(np.int32, np.float64)
-
-    # file identifier
     bytes_file += _create_file_identifier()
-
-    # global header
     bytes_file += _create_global_header()
 
     # create 1 block for gas
@@ -256,8 +240,6 @@ def test_gas_sink_particles():
     nblocks = np.array([2], dtype='int32')
     bytes_file += bytearray(nblocks.tobytes())
     bytes_file += bytearray(read_tag.tobytes())
-
-    print(nblocks)
 
     # 8 particles storing 4 real arrays (x, y, z, h)
     bytes_file += bytearray(read_tag.tobytes())
@@ -328,4 +310,119 @@ def test_gas_sink_particles():
         tm.assert_series_equal(sdf['x'], pd.Series([0, 0, 0, 0, 1, 1, 1, 1, 0.000305]),
                                check_index=False, check_names=False, check_dtype=False)
         tm.assert_series_equal(sdf['h'], pd.Series([1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.0]),
+                               check_index=False, check_names=False, check_dtype=False)
+
+def test_gas_dust_sink_particles():
+
+    bytes_file = _create_capture_pattern(np.int32, np.float64)
+    bytes_file += _create_file_identifier()
+    bytes_file += _create_global_header(massoftype_7=1e-4)
+
+    # create 1 block for gas
+    read_tag = np.array([13], dtype='int32')
+    bytes_file += bytearray(read_tag.tobytes())
+    nblocks = np.array([2], dtype='int32')
+    bytes_file += bytearray(nblocks.tobytes())
+    bytes_file += bytearray(read_tag.tobytes())
+
+    # 8 particles storing 4 real arrays (x, y, z, h)
+    bytes_file += bytearray(read_tag.tobytes())
+    n = np.array([16], dtype='int64')
+    nums = np.array([0, 1, 0, 0, 0, 4, 0, 0] , dtype='int32')
+    bytes_file += bytearray(n.tobytes())
+    bytes_file += bytearray(nums.tobytes())
+    bytes_file += bytearray(read_tag.tobytes())
+
+    bytes_file += bytearray(read_tag.tobytes())
+    n = np.array([1], dtype='int64')
+    nums = np.array([0, 0, 0, 0, 0, 7, 0, 0] , dtype='int32')
+    bytes_file += bytearray(n.tobytes())
+    bytes_file += bytearray(nums.tobytes())
+    bytes_file += bytearray(read_tag.tobytes())
+
+    # write 5 gas/dust particle arrays
+    bytes_file += _create_particle_array("itype", [1, 1, 1, 1, 1, 1, 1, 1,
+                                         7, 7, 7, 7, 7, 7, 7, 7], np.int8)
+    bytes_file += _create_particle_array("x", [0, 0, 0, 0, 1, 1, 1, 1,
+                                               0.5, 0.5, 0.5, 0.5, 1.5, 1.5, 1.5, 1.5])
+    bytes_file += _create_particle_array("y", [0, 0, 1, 1, 0, 0, 1, 1,
+                                               0.5, 0.5, 1.5, 1.5, 0.5, 0.5, 1.5, 1.5])
+    bytes_file += _create_particle_array("z", [0, 1, 0, 1, 0, 1, 0, 1,
+                                               0.5, 1.5, 0.5, 1.5, 0.5, 1.5, 0.5, 1.5])
+    bytes_file += _create_particle_array("h", [1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1,
+                                               1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1])
+
+    # write 7 sink particle arrays
+    bytes_file += _create_particle_array("x", [0.000305])
+    bytes_file += _create_particle_array("y", [-0.035809])
+    bytes_file += _create_particle_array("z", [-0.000035])
+    bytes_file += _create_particle_array("h", [1.0])
+    bytes_file += _create_particle_array("spinx", [-3.911744e-8])
+    bytes_file += _create_particle_array("spiny", [-1.326062e-8])
+    bytes_file += _create_particle_array("spinz", [0.00058])
+
+    with tempfile.NamedTemporaryFile() as fp:
+        fp.write(bytes_file)
+        fp.seek(0)
+
+        sdf_g, sdf_d, sdf_sinks = sarracen.read_phantom(fp.name, separate_types='all')
+        assert sdf_g.params['massoftype'] == 1e-6
+        assert sdf_g.params['massoftype_7'] == 1e-4
+        assert sdf_g.params['mass'] == 1e-6
+        assert sdf_d.params['massoftype'] == 1e-6
+        assert sdf_d.params['massoftype_7'] == 1e-4
+        assert sdf_d.params['mass'] == 1e-4
+        assert sdf_sinks.params['massoftype'] == 1e-6
+        assert sdf_sinks.params['massoftype_7'] == 1e-4
+        assert 'mass' not in sdf_sinks.params
+        assert 'mass' not in sdf_g.columns
+        assert 'mass' not in sdf_d.columns
+        assert 'mass' not in sdf_sinks.columns
+        tm.assert_series_equal(sdf_g['x'],
+                               pd.Series([0, 0, 0, 0, 1, 1, 1, 1]),
+                               check_index=False, check_names=False, check_dtype=False)
+        tm.assert_series_equal(sdf_d['x'],
+                               pd.Series([0.5, 0.5, 0.5, 0.5, 1.5, 1.5, 1.5, 1.5]),
+                               check_index=False, check_names=False, check_dtype=False)
+        tm.assert_series_equal(sdf_sinks['x'], pd.Series([0.000305]),
+                               check_index=False, check_names=False, check_dtype=False)
+        tm.assert_series_equal(sdf_sinks['spinx'], pd.Series([-3.911744e-8]),
+                               check_index=False, check_names=False, check_dtype=False)
+
+        sdf, sdf_sinks = sarracen.read_phantom(fp.name, separate_types='sinks')
+        assert sdf.params['massoftype'] == 1e-6
+        assert sdf.params['massoftype_7'] == 1e-4
+        assert 'mass' not in sdf.params
+        assert 'mass' in sdf.columns
+        assert sdf[sdf.itype == 1]['mass'].unique() == [1e-6]
+        assert sdf[sdf.itype == 7]['mass'].unique() == [1e-4]
+        tm.assert_series_equal(sdf[sdf.itype == 1]['x'],
+                               pd.Series([0, 0, 0, 0, 1, 1, 1, 1]),
+                               check_index=False, check_names=False, check_dtype=False)
+        tm.assert_series_equal(sdf[sdf.itype == 7]['x'],
+                               pd.Series([0.5, 0.5, 0.5, 0.5, 1.5, 1.5, 1.5, 1.5]),
+                               check_index=False, check_names=False, check_dtype=False)
+        assert sdf_sinks.params['massoftype'] == 1e-6
+        assert sdf_sinks.params['massoftype_7'] == 1e-4
+        assert 'mass' not in sdf_sinks.params
+        assert 'mass' not in sdf_sinks.columns
+        tm.assert_series_equal(sdf_sinks['x'], pd.Series([0.000305]),
+                               check_index=False, check_names=False, check_dtype=False)
+        tm.assert_series_equal(sdf_sinks['spinx'], pd.Series([-3.911744e-8]),
+                               check_index=False, check_names=False, check_dtype=False)
+
+        sdf = sarracen.read_phantom(fp.name, separate_types=None)
+        assert sdf.params['massoftype'] == 1e-6
+        assert sdf.params['massoftype_7'] == 1e-4
+        assert 'mass' not in sdf.params
+        assert 'mass' in sdf.columns
+        assert sdf[sdf.itype == 1]['mass'].unique() == [1e-6]
+        assert sdf[sdf.itype == 7]['mass'].unique() == [1e-4]
+        tm.assert_series_equal(sdf['x'], pd.Series([0, 0, 0, 0, 1, 1, 1, 1,
+                                                    0.5, 0.5, 0.5, 0.5, 1.5, 1.5, 1.5, 1.5,
+                                                    0.000305]),
+                               check_index=False, check_names=False, check_dtype=False)
+        tm.assert_series_equal(sdf['h'], pd.Series([1.1] * 16 + [1.0]),
+                               check_index=False, check_names=False, check_dtype=False)
+        tm.assert_series_equal(sdf['mass'], pd.Series([1e-6] * 8 + [1e-4] * 8 + [np.nan]),
                                check_index=False, check_names=False, check_dtype=False)

--- a/sarracen/tests/readers/test_read_phantom.py
+++ b/sarracen/tests/readers/test_read_phantom.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import numpy as np
+import io
+from pandas import testing as tm
+from sarracen.readers import _read_capture_pattern
+import pytest
+
+
+@pytest.mark.parametrize("def_int, def_real",
+                         [(np.int32, np.float64), (np.int32, np.float32),
+                          (np.int64, np.float64), (np.int64, np.float32)])
+def test_determine_default_precision(def_int, def_real):
+    """ Test if default int / real precision can be determined. """
+    # construct capture pattern
+    read_tag = np.array([13], dtype='int32')
+    i1 = np.array([60769], dtype=def_int)
+    r2 = np.array([60878], dtype=def_real)
+    i2 = np.array([60878], dtype=def_int)
+    iversion = np.array([0], dtype=def_int)
+    i3 = np.array([690706], dtype=def_int)
+
+    capture_pattern = bytearray(read_tag.tobytes())
+    capture_pattern += bytearray(i1.tobytes())
+    capture_pattern += bytearray(r2.tobytes())
+    capture_pattern += bytearray(i2.tobytes())
+    capture_pattern += bytearray(iversion.tobytes())
+    capture_pattern += bytearray(i3.tobytes())
+    capture_pattern += bytearray(read_tag.tobytes())
+
+    f = io.BytesIO(capture_pattern)
+    returned_int, returned_real = _read_capture_pattern(f)
+    assert returned_int == def_int
+    assert returned_real == def_real
+

--- a/sarracen/tests/readers/test_read_phantom.py
+++ b/sarracen/tests/readers/test_read_phantom.py
@@ -3,15 +3,14 @@ import numpy as np
 import io
 from pandas import testing as tm
 from sarracen.readers import _read_capture_pattern
+import sarracen
 import pytest
+import tempfile
 
 
-@pytest.mark.parametrize("def_int, def_real",
-                         [(np.int32, np.float64), (np.int32, np.float32),
-                          (np.int64, np.float64), (np.int64, np.float32)])
-def test_determine_default_precision(def_int, def_real):
-    """ Test if default int / real precision can be determined. """
-    # construct capture pattern
+def _create_capture_pattern(def_int, def_real):
+    """ Construct capture pattern. """
+
     read_tag = np.array([13], dtype='int32')
     i1 = np.array([60769], dtype=def_int)
     r2 = np.array([60878], dtype=def_real)
@@ -27,8 +26,215 @@ def test_determine_default_precision(def_int, def_real):
     capture_pattern += bytearray(i3.tobytes())
     capture_pattern += bytearray(read_tag.tobytes())
 
+    return capture_pattern
+
+def _create_file_identifier():
+    """ Construct 100-character file identifier. """
+
+    read_tag = np.array([13], dtype='int32')
+    file_identifier = "Test of read_phantom".ljust(100)
+    bytes_file = bytearray(read_tag.tobytes())
+    bytes_file += bytearray(map(ord, file_identifier))
+    bytes_file += bytearray(read_tag.tobytes())
+    return bytes_file
+
+
+def _create_global_header(massoftype=1e-6, massoftype_7=None):
+    """ Construct global variables. Only massoftype in this example. """
+
+    read_tag = np.array([13], dtype='int32')
+    bytes_file = bytearray()
+    for i in range(8):
+        bytes_file += bytearray(read_tag.tobytes())
+        nvars = (i == 5) + (massoftype_7 is not None)
+        if i == 5:
+            nvars = np.array([nvars], dtype='int32')
+        else:
+            nvars = np.array([0], dtype='int32')
+        bytes_file += bytearray(nvars.tobytes())
+        bytes_file += bytearray(read_tag.tobytes())
+
+        if i == 5:
+            bytes_file += bytearray(read_tag.tobytes())
+            bytes_file += bytearray(map(ord, "massoftype".ljust(16)))
+            if massoftype_7 is not None:
+                bytes_file += bytearray(map(ord, "massoftype_7".ljust(16)))
+            bytes_file += bytearray(read_tag.tobytes())
+
+        if i == 5:
+            bytes_file += bytearray(read_tag.tobytes())
+            bytes_file += bytearray(np.array([massoftype], dtype=np.float64))
+            if massoftype_7 is not None:
+                bytes_file += bytearray(np.array([massoftype_7], dtype=np.float64))
+            bytes_file += bytearray(read_tag.tobytes())
+
+
+    return bytes_file
+
+def _create_particle_array(tag, data, dtype=np.float64):
+    read_tag = np.array([13], dtype='int32')
+    bytes_file = bytearray(read_tag.tobytes())
+    bytes_file += bytearray(map(ord,tag.ljust(16)))
+    bytes_file += bytearray(read_tag.tobytes())
+    bytes_file += bytearray(read_tag.tobytes())
+    bytes_file += bytearray(np.array(data, dtype=dtype).tobytes())
+    bytes_file += bytearray(read_tag.tobytes())
+    return bytes_file
+
+
+@pytest.mark.parametrize("def_int, def_real",
+                         [(np.int32, np.float64), (np.int32, np.float32),
+                          (np.int64, np.float64), (np.int64, np.float32)])
+def test_determine_default_precision(def_int, def_real):
+    """ Test if default int / real precision can be determined. """
+
+    capture_pattern = _create_capture_pattern(def_int, def_real)
+
     f = io.BytesIO(capture_pattern)
     returned_int, returned_real = _read_capture_pattern(f)
     assert returned_int == def_int
     assert returned_real == def_real
 
+
+def test_gas_particles_only():
+
+    # capture pattern
+    bytes_file = _create_capture_pattern(np.int32, np.float64)
+
+    # file identifier
+    bytes_file += _create_file_identifier()
+
+    # global header
+    bytes_file += _create_global_header()
+
+    # create 1 block for gas
+    read_tag = np.array([13], dtype='int32')
+    bytes_file += bytearray(read_tag.tobytes())
+    nblocks = np.array([1], dtype='int32')
+    bytes_file += bytearray(nblocks.tobytes())
+    bytes_file += bytearray(read_tag.tobytes())
+
+    # 8 particles storing 4 real arrays (x, y, z, h)
+    bytes_file += bytearray(read_tag.tobytes())
+    n = np.array([8], dtype='int64')
+    nums = np.array([0, 0, 0, 0, 0, 4, 0, 0], dtype='int32')
+    bytes_file += bytearray(n.tobytes())
+    bytes_file += bytearray(nums.tobytes())
+    bytes_file += bytearray(read_tag.tobytes())
+
+    # write 4 particle arrays
+    bytes_file += _create_particle_array("x", [0, 0, 0, 0, 1, 1, 1, 1])
+    bytes_file += _create_particle_array("y", [0, 0, 1, 1, 0, 0, 1, 1])
+    bytes_file += _create_particle_array("z", [0, 1, 0, 1, 0, 1, 0, 1])
+    bytes_file += _create_particle_array("h", [1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1])
+
+    with tempfile.NamedTemporaryFile() as fp:
+        fp.write(bytes_file)
+        fp.seek(0)
+
+        sdf = sarracen.read_phantom(fp.name, separate_types='all')
+        assert sdf.params['massoftype'] == 1e-6
+        assert sdf.params['mass'] == 1e-6
+        assert 'mass' not in sdf.columns
+        tm.assert_series_equal(sdf['x'], pd.Series([0, 0, 0, 0, 1, 1, 1, 1]),
+                               check_index=False, check_names=False, check_dtype=False)
+
+        sdf = sarracen.read_phantom(fp.name, separate_types='sinks')
+        assert sdf.params['massoftype'] == 1e-6
+        assert sdf.params['mass'] == 1e-6
+        assert 'mass' not in sdf.columns
+        tm.assert_series_equal(sdf['x'], pd.Series([0, 0, 0, 0, 1, 1, 1, 1]),
+                               check_index=False, check_names=False, check_dtype=False)
+
+        sdf = sarracen.read_phantom(fp.name, separate_types=None)
+        assert sdf.params['massoftype'] == 1e-6
+        assert sdf.params['mass'] == 1e-6
+        assert 'mass' not in sdf.columns
+        tm.assert_series_equal(sdf['x'], pd.Series([0, 0, 0, 0, 1, 1, 1, 1]),
+                               check_index=False, check_names=False, check_dtype=False)
+
+def test_gas_dust_particles():
+
+    # capture pattern
+    bytes_file = _create_capture_pattern(np.int32, np.float64)
+
+    # file identifier
+    bytes_file += _create_file_identifier()
+
+    # global header
+    bytes_file += _create_global_header(massoftype_7=1e-4)
+
+    # create 1 block for gas
+    read_tag = np.array([13], dtype='int32')
+    bytes_file += bytearray(read_tag.tobytes())
+    nblocks = np.array([1], dtype='int32')
+    bytes_file += bytearray(nblocks.tobytes())
+    bytes_file += bytearray(read_tag.tobytes())
+
+    # 8 particles storing 4 real arrays (x, y, z, h)
+    bytes_file += bytearray(read_tag.tobytes())
+    n = np.array([16], dtype='int64')
+    nums = np.array([1, 0, 0, 0, 0, 4, 0, 0], dtype='int32')
+    bytes_file += bytearray(n.tobytes())
+    bytes_file += bytearray(nums.tobytes())
+    bytes_file += bytearray(read_tag.tobytes())
+
+    # write 4 particle arrays
+
+    bytes_file += _create_particle_array("itype", [1, 1, 1, 1, 1, 1, 1, 1,
+                                         7, 7, 7, 7, 7, 7, 7, 7], np.int32)
+    bytes_file += _create_particle_array("x", [0, 0, 0, 0, 1, 1, 1, 1,
+                                               0.5, 0.5, 0.5, 0.5, 1.5, 1.5, 1.5, 1.5])
+    bytes_file += _create_particle_array("y", [0, 0, 1, 1, 0, 0, 1, 1,
+                                               0.5, 0.5, 1.5, 1.5, 0.5, 0.5, 1.5, 1.5])
+    bytes_file += _create_particle_array("z", [0, 1, 0, 1, 0, 1, 0, 1,
+                                               0.5, 1.5, 0.5, 1.5, 0.5, 1.5, 0.5, 1.5])
+    bytes_file += _create_particle_array("h", [1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1,
+                                               1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1])
+    with tempfile.NamedTemporaryFile() as fp:
+        fp.write(bytes_file)
+        fp.seek(0)
+
+        sdf_g, sdf_d = sarracen.read_phantom(fp.name, separate_types='all')
+        assert sdf_g.params['massoftype'] == 1e-6
+        assert sdf_g.params['massoftype_7'] == 1e-4
+        assert sdf_g.params['mass'] == 1e-6
+        assert sdf_d.params['massoftype'] == 1e-6
+        assert sdf_d.params['massoftype_7'] == 1e-4
+        assert sdf_d.params['mass'] == 1e-4
+        assert 'mass' not in sdf_g.columns
+        assert 'mass' not in sdf_d.columns
+        tm.assert_series_equal(sdf_g['x'],
+                               pd.Series([0, 0, 0, 0, 1, 1, 1, 1]),
+                               check_index=False, check_names=False, check_dtype=False)
+        tm.assert_series_equal(sdf_d['x'],
+                               pd.Series([0.5, 0.5, 0.5, 0.5, 1.5, 1.5, 1.5, 1.5]),
+                               check_index=False, check_names=False, check_dtype=False)
+
+        sdf = sarracen.read_phantom(fp.name, separate_types='sinks')
+        assert sdf.params['massoftype'] == 1e-6
+        assert sdf.params['massoftype_7'] == 1e-4
+        assert 'mass' not in sdf.params
+        assert 'mass' in sdf.columns
+        assert sdf[sdf.itype == 1]['mass'].unique() == [1e-6]
+        assert sdf[sdf.itype == 7]['mass'].unique() == [1e-4]
+        tm.assert_series_equal(sdf[sdf.itype == 1]['x'],
+                               pd.Series([0, 0, 0, 0, 1, 1, 1, 1]),
+                               check_index=False, check_names=False, check_dtype=False)
+        tm.assert_series_equal(sdf[sdf.itype == 7]['x'],
+                               pd.Series([0.5, 0.5, 0.5, 0.5, 1.5, 1.5, 1.5, 1.5]),
+                               check_index=False, check_names=False, check_dtype=False)
+
+        sdf = sarracen.read_phantom(fp.name, separate_types=None)
+        assert sdf.params['massoftype'] == 1e-6
+        assert sdf.params['massoftype_7'] == 1e-4
+        assert 'mass' not in sdf.params
+        assert 'mass' in sdf.columns
+        assert sdf[sdf.itype == 1]['mass'].unique() == [1e-6]
+        assert sdf[sdf.itype == 7]['mass'].unique() == [1e-4]
+        tm.assert_series_equal(sdf[sdf.itype == 1]['x'],
+                               pd.Series([0, 0, 0, 0, 1, 1, 1, 1]),
+                               check_index=False, check_names=False, check_dtype=False)
+        tm.assert_series_equal(sdf[sdf.itype == 7]['x'],
+                               pd.Series([0.5, 0.5, 0.5, 0.5, 1.5, 1.5, 1.5, 1.5]),
+                               check_index=False, check_names=False, check_dtype=False)

--- a/sarracen/tests/readers/test_read_phantom.py
+++ b/sarracen/tests/readers/test_read_phantom.py
@@ -174,7 +174,7 @@ def test_gas_dust_particles():
     # 8 particles storing 4 real arrays (x, y, z, h)
     bytes_file += bytearray(read_tag.tobytes())
     n = np.array([16], dtype='int64')
-    nums = np.array([1, 0, 0, 0, 0, 4, 0, 0], dtype='int32')
+    nums = np.array([0, 1, 0, 0, 0, 4, 0, 0], dtype='int32')
     bytes_file += bytearray(n.tobytes())
     bytes_file += bytearray(nums.tobytes())
     bytes_file += bytearray(read_tag.tobytes())
@@ -182,7 +182,7 @@ def test_gas_dust_particles():
     # write 4 particle arrays
 
     bytes_file += _create_particle_array("itype", [1, 1, 1, 1, 1, 1, 1, 1,
-                                         7, 7, 7, 7, 7, 7, 7, 7], np.int32)
+                                         7, 7, 7, 7, 7, 7, 7, 7], np.int8)
     bytes_file += _create_particle_array("x", [0, 0, 0, 0, 1, 1, 1, 1,
                                                0.5, 0.5, 0.5, 0.5, 1.5, 1.5, 1.5, 1.5])
     bytes_file += _create_particle_array("y", [0, 0, 1, 1, 0, 0, 1, 1,
@@ -237,4 +237,95 @@ def test_gas_dust_particles():
                                check_index=False, check_names=False, check_dtype=False)
         tm.assert_series_equal(sdf[sdf.itype == 7]['x'],
                                pd.Series([0.5, 0.5, 0.5, 0.5, 1.5, 1.5, 1.5, 1.5]),
+                               check_index=False, check_names=False, check_dtype=False)
+
+def test_gas_sink_particles():
+
+    # capture pattern
+    bytes_file = _create_capture_pattern(np.int32, np.float64)
+
+    # file identifier
+    bytes_file += _create_file_identifier()
+
+    # global header
+    bytes_file += _create_global_header()
+
+    # create 1 block for gas
+    read_tag = np.array([13], dtype='int32')
+    bytes_file += bytearray(read_tag.tobytes())
+    nblocks = np.array([2], dtype='int32')
+    bytes_file += bytearray(nblocks.tobytes())
+    bytes_file += bytearray(read_tag.tobytes())
+
+    print(nblocks)
+
+    # 8 particles storing 4 real arrays (x, y, z, h)
+    bytes_file += bytearray(read_tag.tobytes())
+    n = np.array([8], dtype='int64')
+    nums = np.array([0, 0, 0, 0, 0, 4, 0, 0] , dtype='int32')
+    bytes_file += bytearray(n.tobytes())
+    bytes_file += bytearray(nums.tobytes())
+    bytes_file += bytearray(read_tag.tobytes())
+
+    bytes_file += bytearray(read_tag.tobytes())
+    n = np.array([1], dtype='int64')
+    nums = np.array([0, 0, 0, 0, 0, 7, 0, 0] , dtype='int32')
+    bytes_file += bytearray(n.tobytes())
+    bytes_file += bytearray(nums.tobytes())
+    bytes_file += bytearray(read_tag.tobytes())
+
+    # write 4 gas particle arrays
+    bytes_file += _create_particle_array("x", [0, 0, 0, 0, 1, 1, 1, 1])
+    bytes_file += _create_particle_array("y", [0, 0, 1, 1, 0, 0, 1, 1])
+    bytes_file += _create_particle_array("z", [0, 1, 0, 1, 0, 1, 0, 1])
+    bytes_file += _create_particle_array("h", [1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1])
+
+    # write 7 sink particle arrays
+    bytes_file += _create_particle_array("x", [0.000305])
+    bytes_file += _create_particle_array("y", [-0.035809])
+    bytes_file += _create_particle_array("z", [-0.000035])
+    bytes_file += _create_particle_array("h", [1.0])
+    bytes_file += _create_particle_array("spinx", [-3.911744e-8])
+    bytes_file += _create_particle_array("spiny", [-1.326062e-8])
+    bytes_file += _create_particle_array("spinz", [0.00058])
+
+    with tempfile.NamedTemporaryFile() as fp:
+        fp.write(bytes_file)
+        fp.seek(0)
+
+        sdf, sdf_sinks = sarracen.read_phantom(fp.name, separate_types='all')
+        assert sdf.params['massoftype'] == 1e-6
+        assert sdf_sinks.params['massoftype'] == 1e-6
+        assert sdf.params['mass'] == 1e-6
+        assert 'mass' not in sdf_sinks.params
+        assert 'mass' not in sdf.columns
+        assert 'mass' not in sdf_sinks.columns
+        tm.assert_series_equal(sdf['x'], pd.Series([0, 0, 0, 0, 1, 1, 1, 1]),
+                               check_index=False, check_names=False, check_dtype=False)
+        tm.assert_series_equal(sdf_sinks['x'], pd.Series([0.000305]),
+                               check_index=False, check_names=False, check_dtype=False)
+        tm.assert_series_equal(sdf_sinks['spinx'], pd.Series([-3.911744e-8]),
+                               check_index=False, check_names=False, check_dtype=False)
+
+        sdf, sdf_sinks = sarracen.read_phantom(fp.name, separate_types='sinks')
+        assert sdf.params['massoftype'] == 1e-6
+        assert sdf_sinks.params['massoftype'] == 1e-6
+        assert sdf.params['mass'] == 1e-6
+        assert 'mass' not in sdf_sinks.params
+        assert 'mass' not in sdf.columns
+        assert 'mass' not in sdf_sinks.columns
+        tm.assert_series_equal(sdf['x'], pd.Series([0, 0, 0, 0, 1, 1, 1, 1]),
+                               check_index=False, check_names=False, check_dtype=False)
+        tm.assert_series_equal(sdf_sinks['x'], pd.Series([0.000305]),
+                               check_index=False, check_names=False, check_dtype=False)
+        tm.assert_series_equal(sdf_sinks['spinx'], pd.Series([-3.911744e-8]),
+                               check_index=False, check_names=False, check_dtype=False)
+
+        sdf = sarracen.read_phantom(fp.name, separate_types=None)
+        assert sdf.params['massoftype'] == 1e-6
+        assert sdf.params['mass'] == 1e-6
+        assert 'mass' not in sdf.columns
+        tm.assert_series_equal(sdf['x'], pd.Series([0, 0, 0, 0, 1, 1, 1, 1, 0.000305]),
+                               check_index=False, check_names=False, check_dtype=False)
+        tm.assert_series_equal(sdf['h'], pd.Series([1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.0]),
                                check_index=False, check_names=False, check_dtype=False)


### PR DESCRIPTION
`read_phantom()` creates a `mass` key in `params` to store the global mass of a particle, thereby avoiding storage of duplicated mass values per particle. This doesn't work when a dataframe contains more than 1 species of particles that have different particle masses (e.g., gas + dust).

This PR fixes/changes a few things:
- `read_phantom()` will create a `mass` column if more than 1 particle species is present (multiple `itype`). If there is a single particle species, such as gas only, then it relies on the global variable `mass` in `params` instead, as it has done before. This should fix issue #62.
- `read_phantom()` has reliable detection of 32/64-bit precision for default ints and floats. Previously, this might fail to detect 64-bit ints.
- There are now unit tests of the phantom data reads.