### PR TITLE
added symlognorm for render and tests

### DIFF
--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -282,8 +282,8 @@ def render(data: 'SarracenDataFrame',
     kwargs.setdefault("extent", [xlim[0], xlim[1], ylim[0], ylim[1]])
     if log_scale:
         if symlog_scale:
-            kwargs.setdefault("norm", SymLogNorm(kwargs.get("linthresh", 1e-9), 
-                                                linscale=kwargs.get("linscale", 1.),
+            kwargs.setdefault("norm", SymLogNorm(kwargs.pop("linthresh", 1e-9), 
+                                                linscale=kwargs.pop("linscale", 1.),
                                                 vmin=kwargs.get('vmin'), 
                                                 vmax=kwargs.get('vmax')))
         else:

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -15,7 +15,7 @@ from scipy.spatial.transform import Rotation
 import seaborn as sns
 from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
-from matplotlib.colors import Colormap, LogNorm
+from matplotlib.colors import Colormap, LogNorm, SymLogNorm
 
 from .interpolate import interpolate_2d_line, interpolate_2d, interpolate_3d_proj, interpolate_3d_cross, \
     interpolate_3d_vec, interpolate_3d_cross_vec, interpolate_2d_vec, interpolate_3d_line
@@ -126,6 +126,7 @@ def render(data: 'SarracenDataFrame',
            rotation: Union[np.ndarray, list, Rotation] = None,
            rot_origin: Union[np.ndarray, list, str] = None,
            log_scale: bool = False,
+           symlog_scale: bool = False,
            dens_weight: bool = None,
            normalize: bool = True,
            hmin: bool = False,
@@ -179,6 +180,10 @@ def render(data: 'SarracenDataFrame',
         / 2. Defaults to the midpoint.
     log_scale: bool
         Whether to use a logarithmic scale for color coding.
+    symlog_scale: bool
+        Whether to use a symmetrical logarithmic scale for color coding (i.e., allows positive and negative values).
+        Optionally add "linthresh" and "linscale" to kwargs to set the linear region and the scaling of linear values,
+        respectively (defaults to 1e-9 and 1, respectevely). Only works if log_scale == True.
     dens_weight: bool
         If True, will plot the target mutliplied by the density. Defaults to True for column-integrated views,
         when the target is not density, and False for everything else.
@@ -276,9 +281,15 @@ def render(data: 'SarracenDataFrame',
     kwargs.setdefault("origin", 'lower')
     kwargs.setdefault("extent", [xlim[0], xlim[1], ylim[0], ylim[1]])
     if log_scale:
-        kwargs.setdefault("norm", LogNorm(clip=True, vmin=kwargs.get('vmin'), vmax=kwargs.get('vmax')))
-        kwargs.pop("vmin", None)
-        kwargs.pop("vmax", None)
+        if symlog_scale:
+            kwargs.setdefault("norm", SymLogNorm(kwargs.get("linthresh", 1e-9), 
+                                                linscale=kwargs.get("linscale", 1.),
+                                                vmin=kwargs.get('vmin'), 
+                                                vmax=kwargs.get('vmax')))
+        else:
+            kwargs.setdefault("norm", LogNorm(clip=True, vmin=kwargs.get('vmin'), vmax=kwargs.get('vmax')))
+            kwargs.pop("vmin", None)
+            kwargs.pop("vmax", None)
 
     graphic = ax.imshow(img, cmap=cmap, **kwargs)
     if rotation is not None and data.get_dim() == 3:

--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -288,8 +288,8 @@ def render(data: 'SarracenDataFrame',
                                                 vmax=kwargs.get('vmax')))
         else:
             kwargs.setdefault("norm", LogNorm(clip=True, vmin=kwargs.get('vmin'), vmax=kwargs.get('vmax')))
-            kwargs.pop("vmin", None)
-            kwargs.pop("vmax", None)
+        kwargs.pop("vmin", None)
+        kwargs.pop("vmax", None)
 
     graphic = ax.imshow(img, cmap=cmap, **kwargs)
     if rotation is not None and data.get_dim() == 3:

--- a/sarracen/sarracen_dataframe.py
+++ b/sarracen/sarracen_dataframe.py
@@ -256,11 +256,11 @@ class SarracenDataFrame(DataFrame):
                ylim: Tuple[float, float] = None, cmap: Union[str, Colormap] = 'gist_heat', cbar: bool = True,
                cbar_kws: dict = {}, cbar_ax: Axes = None, ax: Axes = None, exact: bool = None, backend: str = None,
                integral_samples: int = 1000, rotation: Union[np.ndarray, list, Rotation] = None,
-               rot_origin: Union[np.ndarray, list, str] = None, log_scale: bool = None, dens_weight: bool = None,
-               normalize: bool = False, hmin: bool = False, **kwargs) -> Axes:
+               rot_origin: Union[np.ndarray, list, str] = None, log_scale: bool = None, symlog_scale: bool = None,
+               dens_weight: bool = None, normalize: bool = False, hmin: bool = False, **kwargs) -> Axes:
         return render(self, target, x, y, z, xsec, kernel, x_pixels, y_pixels, xlim, ylim, cmap, cbar, cbar_kws,
-                      cbar_ax, ax, exact, backend, integral_samples, rotation, rot_origin, log_scale, dens_weight,
-                      normalize, hmin, **kwargs)
+                      cbar_ax, ax, exact, backend, integral_samples, rotation, rot_origin, log_scale, symlog_scale,
+                      dens_weight, normalize, hmin, **kwargs)
 
     @_copy_doc(lineplot)
     def lineplot(self, target: str, x: str = None, y: str = None, z: str = None,

--- a/sarracen/tests/test_render.py
+++ b/sarracen/tests/test_render.py
@@ -131,10 +131,19 @@ def test_kwargs(backend):
     df_3 = pd.DataFrame({'x': [3, 6], 'y': [5, 1], 'z': [2, 1], 'P': [1, 1], 'h': [1, 1], 'rho': [1, 1], 'm': [1, 1]})
     sdf_3 = SarracenDataFrame(df_3)
     sdf_3.backend = backend
+    df_4 = pd.DataFrame({'x': [-3, 6], 'y': [5, -1], 'z': [2, 1], 'P': [-1, 1], 'h': [1, 1], 'rho': [-1, -1], 'm': [1, 1]})
+    sdf_4 = SarracenDataFrame(df_4)
+    sdf_4.backend = backend
 
     for args in [{'data': sdf_2, 'xsec': None}, {'data': sdf_3, 'xsec': None}, {'data': sdf_3, 'xsec': 1.5}]:
         fig, ax = plt.subplots()
         render(args['data'], 'P', xsec=args['xsec'], ax=ax, origin='upper')
+        assert ax.images[0].origin == 'upper'
+        plt.close(fig)
+    
+    for arg in [True, False]:
+        fig, ax = plt.subplots()
+        render(sdf_4, 'P', ax=ax, log_scale=arg, symlog_scale=True, origin='upper')
         assert ax.images[0].origin == 'upper'
         plt.close(fig)
 

--- a/sarracen/tests/test_render.py
+++ b/sarracen/tests/test_render.py
@@ -143,7 +143,7 @@ def test_kwargs(backend):
     
     for arg in [True, False]:
         fig, ax = plt.subplots()
-        render(sdf_4, 'P', ax=ax, log_scale=arg, symlog_scale=True, origin='upper')
+        render(sdf_4, 'P', ax=ax, log_scale=arg, symlog_scale=True, origin='upper', vmin=-1., vmax=1.)
         assert ax.images[0].origin == 'upper'
         plt.close(fig)
 


### PR DESCRIPTION
I added the ability to do a symmetric log scale on rendering, which allows data with negative values to be put on log scale as well. A test was added and passed.