### PR TITLE
Restrict log plots to 4 magnitude levels by default

### DIFF
--- a/sarracen/render.py
+++ b/sarracen/render.py
@@ -313,15 +313,18 @@ def render(data: 'SarracenDataFrame',  # noqa: F821
     kwargs.setdefault("origin", 'lower')
     kwargs.setdefault("extent", [xlim[0], xlim[1], ylim[0], ylim[1]])
     if log_scale:
+        # By default, a log scale plot will only cover 4 levels of magnitude.
+        vmin = kwargs.get('vmin', max(10 ** (np.log10(kwargs.get("vmax", img.max())) - 4), img.min()))
+
         if symlog_scale:
             kwargs.setdefault("norm",
                               SymLogNorm(kwargs.pop("linthresh", 1e-9),
                                          linscale=kwargs.pop("linscale", 1.),
-                                         vmin=kwargs.get('vmin'),
+                                         vmin=vmin,
                                          vmax=kwargs.get('vmax')))
         else:
             kwargs.setdefault("norm", LogNorm(clip=True,
-                                              vmin=kwargs.get('vmin'),
+                                              vmin=vmin,
                                               vmax=kwargs.get('vmax')))
         kwargs.pop("vmin", None)
         kwargs.pop("vmax", None)


### PR DESCRIPTION
Similarly to [Splash](https://github.com/danieljprice/splash), restrict log-scale 2d plots to 4 magnitude levels by default (relative to the maximum value). This results in a much better default plot, without low-value particle "bubbles" reducing the visibility of key details.

On a flyby simulation, with `sdf.render(target='rho', log_scale=True)`


Old behavior:
![image](https://github.com/user-attachments/assets/dd106335-c0df-4ebd-b05d-28afb2470dca)

New behavior:
![image](https://github.com/user-attachments/assets/4849c3a1-272e-43dc-9c44-987b84a57a27)
