### PR TITLE
Allow Endian Swap

### DIFF
--- a/sarracen/readers/read_phantom.py
+++ b/sarracen/readers/read_phantom.py
@@ -136,7 +136,7 @@ def _read_global_header_block(fp: IO,
         keys = [keys_str[i:i+16].strip() for i in range(0, len(keys_str), 16)]
 
         raw_data = _read_fortran_block(fp, dtype().itemsize*nvars)
-        data_np= np.frombuffer(raw_data, count=nvars, dtype=dtype)
+        data_np = np.frombuffer(raw_data, count=nvars, dtype=dtype)
         if swap_endian:
             data_np = data_np.byteswap()
         data = list(data_np)
@@ -231,13 +231,13 @@ def _read_array_blocks(fp: IO,
         for i in range(0, nblocks):
             start_tag = fp.read(4)
 
-        n_val = np.frombuffer(fp.read(8), dtype=np.int64)[0]
-        nums_val = np.frombuffer(fp.read(32), count=8, dtype=np.int32)
-        if swap_endian:
-            n_val = n_val.byteswap()
-            nums_val = nums_val.byteswap()
-        n.append(n_val)
-        nums.append(nums_val)
+            n_val = np.frombuffer(fp.read(8), dtype=np.int64)[0]
+            nums_val = np.frombuffer(fp.read(32), count=8, dtype=np.int32)
+            if swap_endian:
+                n_val = n_val.byteswap()
+                nums_val = nums_val.byteswap()
+            n.append(n_val)
+            nums.append(nums_val)
 
             end_tag = fp.read(4)
             if (start_tag != end_tag):

--- a/sarracen/tests/readers/test_read_phantom.py
+++ b/sarracen/tests/readers/test_read_phantom.py
@@ -11,7 +11,8 @@ from sarracen import SarracenDataFrame
 
 
 def _create_capture_pattern(def_int: Type[np.generic],
-                            def_real: Type[np.generic]) -> bytearray:
+                            def_real: Type[np.generic],
+                            swap_endian: bool = False) -> bytearray:
     """ Construct capture pattern. """
 
     read_tag = np.array([13], dtype='int32')
@@ -20,6 +21,14 @@ def _create_capture_pattern(def_int: Type[np.generic],
     i2: np.ndarray = np.array([60878], dtype=def_int)
     iversion: np.ndarray = np.array([0], dtype=def_int)
     i3: np.ndarray = np.array([690706], dtype=def_int)
+
+    if swap_endian:
+        read_tag = read_tag.byteswap()
+        i1 = i1.byteswap()
+        r2 = r2.byteswap()
+        i2 = i2.byteswap()
+        iversion = iversion.byteswap()
+        i3 = i3.byteswap()
 
     capture_pattern = bytearray(read_tag.tobytes())
     capture_pattern += bytearray(i1.tobytes())
@@ -102,50 +111,67 @@ def _create_particle_array(tag: str,
                            data: list,
                            dtype: Type[np.generic] = np.float64,
                            swap_endian: bool = False) -> bytearray:
+
     read_tag = np.array([13], dtype='int32')
+    data_np = np.array(data, dtype=dtype)
     if swap_endian:
         read_tag = read_tag.byteswap()
+        data_np = data_np.byteswap()
+
     file = bytearray(read_tag.tobytes())
     file += bytearray(map(ord, tag.ljust(16)))
     file += bytearray(read_tag.tobytes())
     file += bytearray(read_tag.tobytes())
-    data_np = np.array(data, dtype=dtype)
-    if swap_endian:
-        data_np = data_np.byteswap()
     file += bytearray(data_np.tobytes())
     file += bytearray(read_tag.tobytes())
     return file
 
 
-@pytest.mark.parametrize("def_int, def_real",
-                         [(np.int32, np.float64), (np.int32, np.float32),
-                          (np.int64, np.float64), (np.int64, np.float32)])
+@pytest.mark.parametrize("def_int, def_real, swap_endian",
+                         [(np.int32, np.float64, False),
+                          (np.int32, np.float32, False),
+                          (np.int64, np.float64, False),
+                          (np.int64, np.float32, False),
+                          (np.int32, np.float64, True),
+                          (np.int32, np.float32, True),
+                          (np.int64, np.float64, True),
+                          (np.int64, np.float32, True)])
 def test_determine_default_precision(def_int: Type[np.generic],
-                                     def_real: Type[np.generic]) -> None:
+                                     def_real: Type[np.generic],
+                                     swap_endian: bool) -> None:
     """ Test if default int / real precision can be determined. """
 
-    file = _create_capture_pattern(def_int, def_real)
-    file += _create_file_identifier()
-    file += _create_global_header(def_int=def_int, def_real=def_real)
+    file = _create_capture_pattern(def_int, def_real, swap_endian)
+    file += _create_file_identifier(swap_endian)
+    file += _create_global_header(def_int=def_int, def_real=def_real,
+                                  swap_endian=swap_endian)
 
     # create 1 block for gas
     read_tag = np.array([13], dtype='int32')
-    file += bytearray(read_tag.tobytes())
     nblocks = np.array([1], dtype='int32')
+    if swap_endian:
+        read_tag = read_tag.byteswap()
+        nblocks = nblocks.byteswap()
+    file += bytearray(read_tag.tobytes())
     file += bytearray(nblocks.tobytes())
     file += bytearray(read_tag.tobytes())
 
     # 2 particles storing 1 default int and real arrays
-    file += bytearray(read_tag.tobytes())
     n = np.array([2], dtype='int64')
     nums = np.array([1, 0, 0, 0, 0, 1, 0, 0], dtype='int32')
+    if swap_endian:
+        n = n.byteswap()
+        nums = nums.byteswap()
+    file += bytearray(read_tag.tobytes())
     file += bytearray(n.tobytes())
     file += bytearray(nums.tobytes())
     file += bytearray(read_tag.tobytes())
 
     # write particle arrays
-    file += _create_particle_array("def_int", [1, 2], dtype=def_int)
-    file += _create_particle_array("def_real", [1.0, 2.0], dtype=def_real)
+    file += _create_particle_array("def_int", [1, 2],
+                                   def_int, swap_endian)
+    file += _create_particle_array("def_real", [1.0, 2.0],
+                                   def_real, swap_endian)
 
     with tempfile.NamedTemporaryFile() as fp:
         fp.write(file)
@@ -156,17 +182,26 @@ def test_determine_default_precision(def_int: Type[np.generic],
         assert list(sdf.dtypes) == [def_int, def_real]
 
 
-@pytest.mark.parametrize("mpi_blocks", [1, 2, 4])
-def test_gas_particles_only(mpi_blocks) -> None:
+@pytest.mark.parametrize("mpi_blocks, swap_endian",
+                         [(1, False), (1, True),
+                          (2, False), (2, True),
+                          (4, False), (4, True)])
+def test_gas_particles_only(mpi_blocks: int, swap_endian: bool) -> None:
 
-    file = _create_capture_pattern(np.int32, np.float64)
-    file += _create_file_identifier()
-    file += _create_global_header(mpi_blocks=mpi_blocks)
+    def_int = np.int32
+    def_real = np.float64
+    file = _create_capture_pattern(def_int, def_real, swap_endian)
+    file += _create_file_identifier(swap_endian)
+    file += _create_global_header(mpi_blocks=mpi_blocks,
+                                  swap_endian=swap_endian)
 
     # create block for gas (broken into number of mpi_blocks)
     read_tag = np.array([13], dtype='int32')
-    file += bytearray(read_tag.tobytes())
     nblocks = np.array([mpi_blocks], dtype='int32')
+    if swap_endian:
+        read_tag = read_tag.byteswap()
+        nblocks = nblocks.byteswap()
+    file += bytearray(read_tag.tobytes())
     file += bytearray(nblocks.tobytes())
     file += bytearray(read_tag.tobytes())
 
@@ -178,9 +213,12 @@ def test_gas_particles_only(mpi_blocks) -> None:
     for i in range(mpi_blocks):
         # block header
         # 8 particles storing 4 real arrays (x, y, z, h)
-        file += bytearray(read_tag.tobytes())
         n = np.array([8 / mpi_blocks], dtype='int64')
         nums = np.array([0, 0, 0, 0, 0, 4, 0, 0], dtype='int32')
+        if swap_endian:
+            n = n.byteswap()
+            nums = nums.byteswap()
+        file += bytearray(read_tag.tobytes())
         file += bytearray(n.tobytes())
         file += bytearray(nums.tobytes())
         file += bytearray(read_tag.tobytes())
@@ -190,10 +228,14 @@ def test_gas_particles_only(mpi_blocks) -> None:
         size = len(x) // mpi_blocks
         start = i * size
         end = (i + 1) * size
-        file += _create_particle_array("x", x[start:end])
-        file += _create_particle_array("y", y[start:end])
-        file += _create_particle_array("z", z[start:end])
-        file += _create_particle_array("h", h[start:end])
+        file += _create_particle_array("x", x[start:end],
+                                       def_real, swap_endian)
+        file += _create_particle_array("y", y[start:end],
+                                       def_real, swap_endian)
+        file += _create_particle_array("z", z[start:end],
+                                       def_real, swap_endian)
+        file += _create_particle_array("h", h[start:end],
+                                       def_real, swap_endian)
 
     with tempfile.NamedTemporaryFile() as fp:
         fp.write(file)
@@ -205,7 +247,7 @@ def test_gas_particles_only(mpi_blocks) -> None:
         assert sdf.params['massoftype'] == 1e-6
         assert sdf.params['mass'] == 1e-6
         assert 'mass' not in sdf.columns
-        tm.assert_series_equal(sdf['x'], pd.Series([0, 0, 0, 0, 1, 1, 1, 1]),
+        tm.assert_series_equal(sdf['x'], pd.Series(x),
                                check_index=False, check_names=False,
                                check_dtype=False)
 
@@ -215,7 +257,7 @@ def test_gas_particles_only(mpi_blocks) -> None:
         assert sdf.params['massoftype'] == 1e-6
         assert sdf.params['mass'] == 1e-6
         assert 'mass' not in sdf.columns
-        tm.assert_series_equal(sdf['x'], pd.Series([0, 0, 0, 0, 1, 1, 1, 1]),
+        tm.assert_series_equal(sdf['x'], pd.Series(x),
                                check_index=False, check_names=False,
                                check_dtype=False)
 
@@ -225,22 +267,31 @@ def test_gas_particles_only(mpi_blocks) -> None:
         assert sdf.params['massoftype'] == 1e-6
         assert sdf.params['mass'] == 1e-6
         assert 'mass' not in sdf.columns
-        tm.assert_series_equal(sdf['x'], pd.Series([0, 0, 0, 0, 1, 1, 1, 1]),
+        tm.assert_series_equal(sdf['x'], pd.Series(x),
                                check_index=False, check_names=False,
                                check_dtype=False)
 
 
-@pytest.mark.parametrize("mpi_blocks", [1, 2, 4])
-def test_gas_dust_particles(mpi_blocks) -> None:
+@pytest.mark.parametrize("mpi_blocks, swap_endian",
+                         [(1, False), (1, True),
+                          (2, False), (2, True),
+                          (4, False), (4, True)])
+def test_gas_dust_particles(mpi_blocks: int, swap_endian: bool) -> None:
 
-    file = _create_capture_pattern(np.int32, np.float64)
-    file += _create_file_identifier()
-    file += _create_global_header(massoftype_7=1e-4, mpi_blocks=mpi_blocks)
+    def_int = np.int32
+    def_real = np.float64
+    file = _create_capture_pattern(def_int, def_real, swap_endian)
+    file += _create_file_identifier(swap_endian)
+    file += _create_global_header(massoftype_7=1e-4, mpi_blocks=mpi_blocks,
+                                  swap_endian=swap_endian)
 
     # create block for gas & dust particles
     read_tag = np.array([13], dtype='int32')
-    file += bytearray(read_tag.tobytes())
     nblocks = np.array([mpi_blocks], dtype='int32')
+    if swap_endian:
+        read_tag = read_tag.byteswap()
+        nblocks = nblocks.byteswap()
+    file += bytearray(read_tag.tobytes())
     file += bytearray(nblocks.tobytes())
     file += bytearray(read_tag.tobytes())
 
@@ -258,9 +309,12 @@ def test_gas_dust_particles(mpi_blocks) -> None:
     for i in range(mpi_blocks):
         # block header
         # 8 particles storing 4 real arrays (x, y, z, h)
-        file += bytearray(read_tag.tobytes())
         n = np.array([16 / mpi_blocks], dtype='int64')
         nums = np.array([0, 1, 0, 0, 0, 4, 0, 0], dtype='int32')
+        if swap_endian:
+            n = n.byteswap()
+            nums = nums.byteswap()
+        file += bytearray(read_tag.tobytes())
         file += bytearray(n.tobytes())
         file += bytearray(nums.tobytes())
         file += bytearray(read_tag.tobytes())
@@ -270,11 +324,16 @@ def test_gas_dust_particles(mpi_blocks) -> None:
         size = len(x) // mpi_blocks
         start = i * size
         end = (i + 1) * size
-        file += _create_particle_array("itype", itype[start:end], np.int8)
-        file += _create_particle_array("x", x[start:end])
-        file += _create_particle_array("y", y[start:end])
-        file += _create_particle_array("z", z[start:end])
-        file += _create_particle_array("h", h[start:end])
+        file += _create_particle_array("itype", itype[start:end],
+                                       np.int8, swap_endian)
+        file += _create_particle_array("x", x[start:end],
+                                       def_real, swap_endian)
+        file += _create_particle_array("y", y[start:end],
+                                       def_real, swap_endian)
+        file += _create_particle_array("z", z[start:end],
+                                       def_real, swap_endian)
+        file += _create_particle_array("h", h[start:end],
+                                       def_real, swap_endian)
 
     with tempfile.NamedTemporaryFile() as fp:
         fp.write(file)
@@ -342,17 +401,26 @@ def test_gas_dust_particles(mpi_blocks) -> None:
                                check_dtype=False)
 
 
-@pytest.mark.parametrize("mpi_blocks", [1, 2, 4])
-def test_gas_sink_particles(mpi_blocks) -> None:
+@pytest.mark.parametrize("mpi_blocks, swap_endian",
+                         [(1, False), (1, True),
+                          (2, False), (2, True),
+                          (4, False), (4, True)])
+def test_gas_sink_particles(mpi_blocks: int, swap_endian: bool) -> None:
 
-    file = _create_capture_pattern(np.int32, np.float64)
-    file += _create_file_identifier()
-    file += _create_global_header(mpi_blocks=mpi_blocks)
+    def_int = np.int32
+    def_real = np.float64
+    file = _create_capture_pattern(def_int, def_real, swap_endian)
+    file += _create_file_identifier(swap_endian)
+    file += _create_global_header(mpi_blocks=mpi_blocks,
+                                  swap_endian=swap_endian)
 
     # block 1 = gas, block 2 = sinks
     read_tag = np.array([13], dtype='int32')
-    file += bytearray(read_tag.tobytes())
     nblocks = np.array([2 * mpi_blocks], dtype='int32')
+    if swap_endian:
+        read_tag = read_tag.byteswap()
+        nblocks = nblocks.byteswap()
+    file += bytearray(read_tag.tobytes())
     file += bytearray(nblocks.tobytes())
     file += bytearray(read_tag.tobytes())
 
@@ -363,16 +431,22 @@ def test_gas_sink_particles(mpi_blocks) -> None:
 
     for i in range(mpi_blocks):
         # block headers
-        file += bytearray(read_tag.tobytes())
         n = np.array([8 / mpi_blocks], dtype='int64')
         nums = np.array([0, 0, 0, 0, 0, 4, 0, 0], dtype='int32')
+        if swap_endian:
+            n = n.byteswap()
+            nums = nums.byteswap()
+        file += bytearray(read_tag.tobytes())
         file += bytearray(n.tobytes())
         file += bytearray(nums.tobytes())
         file += bytearray(read_tag.tobytes())
 
-        file += bytearray(read_tag.tobytes())
         n = np.array([1], dtype='int64')
         nums = np.array([0, 0, 0, 0, 0, 7, 0, 0], dtype='int32')
+        if swap_endian:
+            n = n.byteswap()
+            nums = nums.byteswap()
+        file += bytearray(read_tag.tobytes())
         file += bytearray(n.tobytes())
         file += bytearray(nums.tobytes())
         file += bytearray(read_tag.tobytes())
@@ -382,20 +456,31 @@ def test_gas_sink_particles(mpi_blocks) -> None:
         size = len(x) // mpi_blocks
         start = i * size
         end = (i + 1) * size
-        file += _create_particle_array("x", x[start:end])
-        file += _create_particle_array("y", y[start:end])
-        file += _create_particle_array("z", z[start:end])
-        file += _create_particle_array("h", h[start:end])
+        file += _create_particle_array("x", x[start:end],
+                                       def_real, swap_endian)
+        file += _create_particle_array("y", y[start:end],
+                                       def_real, swap_endian)
+        file += _create_particle_array("z", z[start:end],
+                                       def_real, swap_endian)
+        file += _create_particle_array("h", h[start:end],
+                                       def_real, swap_endian)
 
         # write 7 sink particle arrays in block 2
         # each mpi_block writes all sink particles (I believe)
-        file += _create_particle_array("x", [0.000305])
-        file += _create_particle_array("y", [-0.035809])
-        file += _create_particle_array("z", [-0.000035])
-        file += _create_particle_array("h", [1.0])
-        file += _create_particle_array("spinx", [-3.911744e-8])
-        file += _create_particle_array("spiny", [-1.326062e-8])
-        file += _create_particle_array("spinz", [0.00058])
+        file += _create_particle_array("x", [0.000305],
+                                       def_real, swap_endian)
+        file += _create_particle_array("y", [-0.035809],
+                                       def_real, swap_endian)
+        file += _create_particle_array("z", [-0.000035],
+                                       def_real, swap_endian)
+        file += _create_particle_array("h", [1.0],
+                                       def_real, swap_endian)
+        file += _create_particle_array("spinx", [-3.911744e-8],
+                                       def_real, swap_endian)
+        file += _create_particle_array("spiny", [-1.326062e-8],
+                                       def_real, swap_endian)
+        file += _create_particle_array("spinz", [0.00058],
+                                       def_real, swap_endian)
 
     with tempfile.NamedTemporaryFile() as fp:
         fp.write(file)
@@ -412,7 +497,7 @@ def test_gas_sink_particles(mpi_blocks) -> None:
         assert 'mass' not in sdf_sinks.params
         assert 'mass' not in sdf.columns
         assert 'mass' not in sdf_sinks.columns
-        tm.assert_series_equal(sdf['x'], pd.Series([0, 0, 0, 0, 1, 1, 1, 1]),
+        tm.assert_series_equal(sdf['x'], pd.Series(x),
                                check_index=False, check_names=False,
                                check_dtype=False)
         tm.assert_series_equal(sdf_sinks['x'], pd.Series([0.000305]),
@@ -433,7 +518,7 @@ def test_gas_sink_particles(mpi_blocks) -> None:
         assert 'mass' not in sdf_sinks.params
         assert 'mass' not in sdf.columns
         assert 'mass' not in sdf_sinks.columns
-        tm.assert_series_equal(sdf['x'], pd.Series([0, 0, 0, 0, 1, 1, 1, 1]),
+        tm.assert_series_equal(sdf['x'], pd.Series(x),
                                check_index=False, check_names=False,
                                check_dtype=False)
         tm.assert_series_equal(sdf_sinks['x'], pd.Series([0.000305]),
@@ -451,29 +536,34 @@ def test_gas_sink_particles(mpi_blocks) -> None:
         assert sdf.params['massoftype'] == 1e-6
         assert sdf.params['mass'] == 1e-6
         assert 'mass' not in sdf.columns
-        tm.assert_series_equal(sdf['x'], pd.Series([0, 0, 0, 0,
-                                                    1, 1, 1, 1,
-                                                    0.000305]),
+        tm.assert_series_equal(sdf['x'], pd.Series(x + [0.000305]),
                                check_index=False, check_names=False,
                                check_dtype=False)
-        tm.assert_series_equal(sdf['h'], pd.Series([1.1, 1.1, 1.1, 1.1,
-                                                    1.1, 1.1, 1.1, 1.1,
-                                                    1.0]),
+        tm.assert_series_equal(sdf['h'], pd.Series(h + [1.0]),
                                check_index=False, check_names=False,
                                check_dtype=False)
 
 
-@pytest.mark.parametrize("mpi_blocks", [1, 2, 4])
-def test_gas_dust_sink_particles(mpi_blocks) -> None:
+@pytest.mark.parametrize("mpi_blocks, swap_endian",
+                         [(1, False), (1, True),
+                          (2, False), (2, True),
+                          (4, False), (4, True)])
+def test_gas_dust_sink_particles(mpi_blocks: int, swap_endian: bool) -> None:
 
-    file = _create_capture_pattern(np.int32, np.float64)
-    file += _create_file_identifier()
-    file += _create_global_header(massoftype_7=1e-4, mpi_blocks=mpi_blocks)
+    def_int = np.int32
+    def_real = np.float64
+    file = _create_capture_pattern(def_int, def_real, swap_endian)
+    file += _create_file_identifier(swap_endian)
+    file += _create_global_header(massoftype_7=1e-4, mpi_blocks=mpi_blocks,
+                                  swap_endian=swap_endian)
 
     # create 1 block for gas
     read_tag = np.array([13], dtype='int32')
-    file += bytearray(read_tag.tobytes())
     nblocks = np.array([2 * mpi_blocks], dtype='int32')
+    if swap_endian:
+        read_tag = read_tag.byteswap()
+        nblocks = nblocks.byteswap()
+    file += bytearray(read_tag.tobytes())
     file += bytearray(nblocks.tobytes())
     file += bytearray(read_tag.tobytes())
 
@@ -491,17 +581,23 @@ def test_gas_dust_sink_particles(mpi_blocks) -> None:
     for i in range(mpi_blocks):
         # block headers
         # gas/dust particles in block 1
-        file += bytearray(read_tag.tobytes())
         n = np.array([16 / mpi_blocks], dtype='int64')
         nums = np.array([0, 1, 0, 0, 0, 4, 0, 0], dtype='int32')
+        if swap_endian:
+            n = n.byteswap()
+            nums = nums.byteswap()
+        file += bytearray(read_tag.tobytes())
         file += bytearray(n.tobytes())
         file += bytearray(nums.tobytes())
         file += bytearray(read_tag.tobytes())
 
         # 1 sink particle in block 2
-        file += bytearray(read_tag.tobytes())
         n = np.array([1], dtype='int64')
         nums = np.array([0, 0, 0, 0, 0, 7, 0, 0], dtype='int32')
+        if swap_endian:
+            n = n.byteswap()
+            nums = nums.byteswap()
+        file += bytearray(read_tag.tobytes())
         file += bytearray(n.tobytes())
         file += bytearray(nums.tobytes())
         file += bytearray(read_tag.tobytes())
@@ -511,21 +607,33 @@ def test_gas_dust_sink_particles(mpi_blocks) -> None:
         size = len(x) // mpi_blocks
         start = i * size
         end = (i + 1) * size
-        file += _create_particle_array("itype", itype[start:end], np.int8)
-        file += _create_particle_array("x", x[start:end])
-        file += _create_particle_array("y", y[start:end])
-        file += _create_particle_array("z", z[start:end])
-        file += _create_particle_array("h", h[start:end])
+        file += _create_particle_array("itype", itype[start:end],
+                                       np.int8, swap_endian)
+        file += _create_particle_array("x", x[start:end],
+                                       def_real, swap_endian)
+        file += _create_particle_array("y", y[start:end],
+                                       def_real, swap_endian)
+        file += _create_particle_array("z", z[start:end],
+                                       def_real, swap_endian)
+        file += _create_particle_array("h", h[start:end],
+                                       def_real, swap_endian)
 
         # write 7 sink particle arrays in block 2
         # each mpi_block writes all sink particles (I believe)
-        file += _create_particle_array("x", [0.000305])
-        file += _create_particle_array("y", [-0.035809])
-        file += _create_particle_array("z", [-0.000035])
-        file += _create_particle_array("h", [1.0])
-        file += _create_particle_array("spinx", [-3.911744e-8])
-        file += _create_particle_array("spiny", [-1.326062e-8])
-        file += _create_particle_array("spinz", [0.00058])
+        file += _create_particle_array("x", [0.000305],
+                                       def_real, swap_endian)
+        file += _create_particle_array("y", [-0.035809],
+                                       def_real, swap_endian)
+        file += _create_particle_array("z", [-0.000035],
+                                       def_real, swap_endian)
+        file += _create_particle_array("h", [1.0],
+                                       def_real, swap_endian)
+        file += _create_particle_array("spinx", [-3.911744e-8],
+                                       def_real, swap_endian)
+        file += _create_particle_array("spiny", [-1.326062e-8],
+                                       def_real, swap_endian)
+        file += _create_particle_array("spinz", [0.00058],
+                                       def_real, swap_endian)
 
     with tempfile.NamedTemporaryFile() as fp:
         fp.write(file)


### PR DESCRIPTION
Phantom dump file reading does not account for endianness, which is required for reading sphNG data. This PR swaps the endianness if required