### PR TITLE
Fix phantom apr mass column miscalculation when apr_level > 7

### DIFF
--- a/sarracen/readers/read_phantom.py
+++ b/sarracen/readers/read_phantom.py
@@ -289,7 +289,7 @@ def _create_aprmass_column(df: pd.DataFrame,
     multiple refinement levels.
     """
     df['mass'] = header_vars['massoftype']
-    df['mass'] = df['mass']/(2**(df['apr_level'] - 1))
+    df['mass'] = df['mass']/(np.float64(2)**(df['apr_level'] - 1))
 
     return df
 


### PR DESCRIPTION
This fix the bug when creating mass columns for phantom dumpfiles with apr on:
When there are more than 7 apr levels, `2**(df['apr_level'] - 1)` will overflow, due to `df['apr_level']` having type of `int8` (meaning `2**(df['apr_level'] - 1)` cannot handle integers larger than 127).