### PR TITLE
add support for Wendland kernels on Shamrock reader

### DIFF
--- a/sarracen/readers/read_shamrock.py
+++ b/sarracen/readers/read_shamrock.py
@@ -301,6 +301,12 @@ def read_shamrock(filename: str) -> SarracenDataFrame:
             hfact = 1.2
         elif kernel[:2] == "M6":
             hfact = 1.0
+        elif kernel[:2] == "C2":
+            hfact = 1.4
+        elif kernel[:2] == "C4":
+            hfact = 1.6
+        elif kernel[:2] == "C6":
+            hfact = 2.2
         else:
             raise KeyError("Unrecognised kernel.")
         metadata["hfact"] = hfact


### PR DESCRIPTION
Add the correct hfact for kernels C2, C4, C6.