### PR TITLE
Returned sigma might have a different length to bins

### DIFF
--- a/sarracen/disc/surface_density.py
+++ b/sarracen/disc/surface_density.py
@@ -147,9 +147,11 @@ def surface_density(data: 'SarracenDataFrame',
 
     mass = _get_mass(data)
     if isinstance(mass, pd.Series):
-        sigma = mass.groupby(rbins).sum()
+        sigma = mass.groupby(rbins, observed=False).sum()
     else:
-        sigma = data.groupby(rbins).count().iloc[:, 0] * mass
+        sigma = data.groupby(rbins, observed=False).size() * mass
+
+    sigma = sigma.reindex(rbins.cat.categories, fill_value=0)
 
     if retbins:
         return (sigma / areas).to_numpy(), _get_bin_midpoints(bin_edges, log)


### PR DESCRIPTION
Looking at a particular phantom file and found that the sigma returned from surface_density could have a different length to the number of bins I requested. It seems to occur when some of the bins have zero particles and that entry is silently dropped. I don't know if anyone else has had this problem but it made it difficult to plot because sigma and bins were not indexed in the same way and had differing lengths. Can provide file for testing if needed.